### PR TITLE
Feature/Support processor decoration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Transactional Outbox is published on `mavenCentral`. In order to use it just add
 
 ```gradle
 
-implementation("io.github.bluegroundltd:transactional-outbox-core:0.2.0")
+implementation("io.github.bluegroundltd:transactional-outbox-core:0.3.0")
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,28 @@ class OutboxMonitor(
 
 }
 ```
+## Local Development
+If you're working on a new version of the `core` module, and you want this version to be available to other project before
+publishing it, you can do so in two ways
 
+* Alternative 1: Install the new version to Maven
+```shell
+$ mvn install:install-file \ 
+   -Dfile=core/build/libs/core-x.y.z.jar \
+   -DgroupId=io.github.bluegroundltd \ 
+   -DartifactId=transactional-outbox-core \
+   -Dversion=x.y.z \
+   -Dpackaging=jar \
+   -DgeneratePom=true
+```
+then depend on the `x.y.z` version as usual. 
+```gradle
+implementation("io.github.bluegroundltd:transactional-outbox-core:x.y.z")
+```
+* Alternative 2: Change your dependencies to directly reference the jar file
+```gradle
+implementation("files("../../../transactional-outbox/core/build/libs/core-x.y.z.jar"))
+```
 ## Publishing
 
 * Bump version in `gradle.properties` of `core` module.

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=io.github.bluegroundltd
 POM_ARTIFACT_ID=transactional-outbox-core
-VERSION_NAME=0.2.0
+VERSION_NAME=0.3.0
 
 POM_NAME=Transactional Outbox Core
 POM_DESCRIPTION=Easily implement the transactional outbox pattern in your JVM application

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxItemProcessorDecorator.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxItemProcessorDecorator.kt
@@ -1,0 +1,14 @@
+package io.github.bluegroundltd.outbox
+
+/**
+ * A callback interface for a decorator to be applied to the internal Outbox Item Processors.
+ *
+ * The primary use case is to set some execution context around the invocation of the [OutboxHandler] that is called
+ * by the asynchronously-invoked Outbox Item Processor, or to provide some monitoring/statistics for the handler's execution.
+ *
+ * Implementations must be **thread-safe**
+ */
+@FunctionalInterface
+interface OutboxItemProcessorDecorator {
+  fun decorate(runnable: Runnable): Runnable
+}

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/executor/FixedThreadPoolExecutorServiceFactory.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/executor/FixedThreadPoolExecutorServiceFactory.kt
@@ -11,12 +11,12 @@ import java.util.concurrent.Executors
  */
 internal class FixedThreadPoolExecutorServiceFactory(
   private val threadPoolSize: Int = DEFAULT_THREAD_POOL_SIZE,
-  private val threadNameFormat: String = DEFAULT_THEAD_NAME_FORMAT
+  private val threadNameFormat: String = DEFAULT_THREAD_NAME_FORMAT
 ) {
 
   companion object {
     private const val DEFAULT_THREAD_POOL_SIZE = 10
-    private const val DEFAULT_THEAD_NAME_FORMAT = "outbox-item-processor-%d"
+    private const val DEFAULT_THREAD_NAME_FORMAT = "outbox-item-processor-%d"
     private val logger: Logger = LoggerFactory.getLogger(FixedThreadPoolExecutorServiceFactory::class.java)
   }
 

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/store/OutboxFilter.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/store/OutboxFilter.kt
@@ -12,13 +12,13 @@ class OutboxPendingFilter(
 ) : AbstractOutboxFilter(OutboxStatus.PENDING)
 
 class OutboxRunningFilter(
-  val rerunAfterGreaterThan: Instant
+  val rerunAfterLessThan: Instant
 ) : AbstractOutboxFilter(OutboxStatus.RUNNING)
 
 class OutboxFilter(
-  nextExecutionAtGreaterThan: Instant,
-  rerunAfterGreaterThan: Instant = nextExecutionAtGreaterThan
+  nextRunLessThan: Instant,
+  rerunAfterLessThan: Instant = nextRunLessThan
 ) {
-  val outboxPendingFilter: OutboxPendingFilter = OutboxPendingFilter(nextExecutionAtGreaterThan)
-  val outboxRunningFilter: OutboxRunningFilter = OutboxRunningFilter(rerunAfterGreaterThan)
+  val outboxPendingFilter: OutboxPendingFilter = OutboxPendingFilter(nextRunLessThan)
+  val outboxRunningFilter: OutboxRunningFilter = OutboxRunningFilter(rerunAfterLessThan)
 }

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
@@ -45,6 +45,7 @@ class TransactionalOutboxImplSpec extends Specification {
       outboxItemFactory,
       DURATION_ONE_HOUR,
       new FixedThreadPoolExecutorServiceFactory(1, "").make(),
+      [],
       DURATION_ONE_NANO
     )
   }

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
@@ -74,7 +74,7 @@ class TransactionalOutboxImplSpec extends Specification {
       1 * store.fetch(_) >> { OutboxFilter filter ->
         with(filter) {
           outboxPendingFilter.nextRunLessThan == now
-          outboxRunningFilter.rerunAfterGreaterThan == now
+          outboxRunningFilter.rerunAfterLessThan == now
         }
         [expectedOutboxItem]
       }

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxAddSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxAddSpec.groovy
@@ -40,6 +40,7 @@ class OutboxAddSpec extends UnitTestSpecification {
       outboxItemFactory,
       DURATION_ONE_HOUR,
       executor,
+      [],
       threadPoolTimeOut
     )
   }

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxMonitorSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxMonitorSpec.groovy
@@ -139,7 +139,7 @@ class OutboxMonitorSpec extends Specification {
       1 * store.fetch(_) >> { OutboxFilter filter ->
         with(filter) {
           outboxPendingFilter.nextRunLessThan == now
-          outboxRunningFilter.rerunAfterGreaterThan == now
+          outboxRunningFilter.rerunAfterLessThan == now
         }
         items
       }

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxShutdownSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxShutdownSpec.groovy
@@ -43,6 +43,7 @@ class OutboxShutdownSpec extends Specification {
       outboxItemFactory,
       DURATION_ONE_HOUR,
       executor,
+      [],
       threadPoolTimeOut
     )
   }


### PR DESCRIPTION
This PR introduces a way to decorate the underlying `OutboxItemProcessor` objects.

## Context 
An `OutboxItemProcessor` is the component that is invoked to handle pending outbox items. It is responsible for calling the corresponding `OutboxHandler` and then marking the `OutboxItem` as `COMPLETED`, `FAILED`, or incrementing the retry counter, depending on the case.

In our applications at Blueground, we often use an Execution Context construct to gather helpful information about a request, incoming message, or scheduled task. This information is mainly used to populate our logging MDC but, in some cases, it can also be accessed directly.

## Problem
In order to set up the Execution Context for an `OutboxHandler`, we annotated its `handle` method with a custom `@ExecutionContext` annotation. An aspect driven by that annotation was then responsible to set up the Execution Context.

This approach, although concise, has two problems
* An engineer can forget to add the annotation
* Even with the annotation in place, the `OutboxItemProcessor` does not have an Execution Context available, despite it being the first component to be invoked asynchronously, in a separate thread. This prevents us from having available the logging context for code executed before the `OutboxHandler` is called.

## Solution
The solution introduced by this PR is to decorate the `OutboxItemProcessor` before they are executed asynchronously. An `OutboxItemProcessorDecorator` is a functional interface and the implementations are fully agnostic about the internals of Transactional Outbox. All the decorator does is accept a `Runnable` and return the decorated `Runnable`.

While the Execution Context use case was mentioned as an example, any kind of logic can be implemented.

Multiple `OutboxItemProcessorDecorator`s can be added through `TransactionalOutboxBuilder`s new `addProcessorDecorator` method. The decorators are applied in the order they were added, i.e. the first decorator will decorate the `OutboxItemProcessor`, and a second decorator will decorate the resulting `Runnable` of the first decorator.
This means that the code within the decorators will be executed in the reverse order.

`OutboxItemProcessorDecorator` implementations should be **thread-safe**