### PR TITLE
chore(ci): add release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  release-core:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17.0.1
+          distribution: 'zulu'
+      - name: Build and test
+        run: ./gradlew core:build
+      - name: Publish package
+        uses: gradle/gradle-build-action@v2.4.2
+        env:
+          # https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
+        with:
+          arguments: core:publishAllPublicationsToMavenCentral --no-configuration-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,12 @@ jobs:
             echo "Tag is not based on a merged commit in the main branch. Exiting."
             exit 0
           fi
+      - name: Check tag name pattern follows `vX.Y.Z`
+        run: |
+          if [[ ! "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag name does not match the pattern 'vX.Y.Z'. Exiting."
+            exit 0
+          fi
       - name: Setup Java
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,17 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
+      - name: Issue a release only if a tag is based on a merged commit in `main` branch
+        run: |
+          tag_commit=$(git rev-parse ${{ github.ref }})
+          merged_commit=$(git rev-parse main)
+
+          if git merge-base --is-ancestor $tag_commit $merged_commit; then
+            echo "Tag is based on a merged commit in the main branch"
+          else
+            echo "Tag is not based on a merged commit in the main branch. Exiting."
+            exit 0
+          fi
       - name: Setup Java
         uses: actions/setup-java@v3
         with:

--- a/README.md
+++ b/README.md
@@ -209,11 +209,32 @@ implementation(files("../../../transactional-outbox/core/build/libs/core-x.y.z.j
 ```
 ## Publishing
 
-* Bump version in `gradle.properties` of `core` module.
+Firstly, bump version in `gradle.properties` of `core` module, commit and push a PR. Once it gets merged, follow one of the two options below.
+
+
+Now, you can either: 
+1. publish via GitHub, or
+2. locally from your machine
+
+### Publish via GitHub
+Using this method has the benefit of not having to provide any secrets whatsoever.  
+Simply, push a git tag **after** a PR is merged, which will trigger the 
+[release.yml](.github/workflows/release.yml) pipeline.  
+Said pipeline, will publish the artifact.
+
+Please note that this will be automated in future work.
+
+#### Tag formatting
+To tag, please follow a format like `v0.4.0`, that is prefixed with `v` and the version number of the artifact you're 
+about to release.  
+
+### Publish via your workstation
+
+* Having built the artifact
 * Execute the following to upload artifact:
 ```shell
-$ ./gradlew :core:publish \
-            --no-daemon --no-parallel \
+$ ./gradlew publishAllPublicationsToMavenCentral \
+            --no-configuration-cache \
             -Psigning.secretKeyRingFile=<keyring_file_path> \
             -Psigning.password=<keyring_password> \
             -Psigning.keyId=<keyring_id> \
@@ -221,12 +242,8 @@ $ ./gradlew :core:publish \
             -PmavenCentralPassword=<nexus_password>
 ```
 
-After this operation finishes, you can promote the artifact to be released with:
-```shell
-$ ./gradlew closeAndReleaseRepository \
-            -PmavenCentralUsername=<nexus_username> \
-            -PmavenCentralPassword=<nexus_password>
-```
+Note that if you maintain the properties above (`-P`) in your local `gradle.properties` file, you can omit them from the
+command.
 
 ## Maintainers
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -103,3 +103,11 @@ apply(plugin = "com.vanniktech.maven.publish")
 tasks.dokkaHtml.configure {
   outputDirectory.set(buildDir.resolve("dokka-html"))
 }
+
+signing {
+  // This is required to allow using the signing key via the CI in ASCII armored format.
+  // https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys
+  val signingKey: String? by project
+  val signingPassword: String? by project
+  useInMemoryPgpKeys(signingKey, signingPassword)
+}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
   jacoco
   id("io.gitlab.arturbosch.detekt")
   id("org.jetbrains.dokka") version "1.5.31"
-  id("com.vanniktech.maven.publish") version "0.18.0"
+  id("com.vanniktech.maven.publish") version "0.25.2"
   id("org.jetbrains.kotlin.plugin.allopen") version "1.8.0"
 }
 
@@ -102,10 +102,4 @@ apply(plugin = "com.vanniktech.maven.publish")
 
 tasks.dokkaHtml.configure {
   outputDirectory.set(buildDir.resolve("dokka-html"))
-}
-
-plugins.withId("com.vanniktech.maven.publish") {
-  mavenPublish {
-    sonatypeHost = com.vanniktech.maven.publish.SonatypeHost.S01
-  }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,9 @@ jacksonVersion=2.14.1
 
 # Slf4j properties
 slf4jVersion=2.0.5
+
+# Publish plugin configuration
+# https://vanniktech.github.io/gradle-maven-publish-plugin/central/#publishing-releases
+SONATYPE_HOST=S01
+RELEASE_SIGNING_ENABLED=true
+SONATYPE_AUTOMATIC_RELEASE=true


### PR DESCRIPTION
Add release pipeline, which is triggered via a tag push, builds the artifact and releases it to the OSSRH repository.

[no-jira]

----
TODO
- [x] Update README with new publish instructions
- [x] (Will be tackled in upcoming PR) Tag => GH release => publish or upon release commit => tag => GH release => publish? 🤔 

----
To test this:
- I've built it locally and published it to my local M2 repo with
- `gradle core:publishToLocalMaven` 
- changed the version in one of our library client repos, to `0.4.4-SNAPSHOT` and the build succeeded

I'd like to test this with a PR in our own repo, so that online resolution works.