### PR TITLE
[SW-287] Add decorators on instant process outbox items

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Transactional Outbox is published on `mavenCentral`. In order to use it just add
 
 ```gradle
 
-implementation("io.github.bluegroundltd:transactional-outbox-core:0.3.0")
+implementation("io.github.bluegroundltd:transactional-outbox-core:0.4.0")
 
 ```
 
@@ -205,7 +205,7 @@ implementation("io.github.bluegroundltd:transactional-outbox-core:x.y.z")
 ```
 * Alternative 2: Change your dependencies to directly reference the jar file
 ```gradle
-implementation("files("../../../transactional-outbox/core/build/libs/core-x.y.z.jar"))
+implementation(files("../../../transactional-outbox/core/build/libs/core-x.y.z.jar"))
 ```
 ## Publishing
 

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=io.github.bluegroundltd
 POM_ARTIFACT_ID=transactional-outbox-core
-VERSION_NAME=0.3.0
+VERSION_NAME=0.4.0
 
 POM_NAME=Transactional Outbox Core
 POM_DESCRIPTION=Easily implement the transactional outbox pattern in your JVM application

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutboxImpl.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutboxImpl.kt
@@ -57,7 +57,7 @@ internal class TransactionalOutboxImpl(
     runCatching {
       logger.info("$LOGGER_PREFIX Instant processing of \"${outbox.type.getType()}\" outbox")
       executor.execute(
-        OutboxItemProcessor(outbox, outboxHandlers[outbox.type]!!, outboxStore)
+        decorate(OutboxItemProcessor(outbox, outboxHandlers[outbox.type]!!, outboxStore))
       )
     }.onFailure {
       logger.error("$LOGGER_PREFIX Failure in instant handling", it)


### PR DESCRIPTION
Outbox items processed instantly are now also decorated.

Mainly needed for outbox handlers which do not have execution context and they are instantly published/processed.
