### PR TITLE
chore(release): pipeline fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           if [[ ! "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Tag name ($GITHUB_REF) does not match the pattern 'vX.Y.Z'. Exiting."
-            exit 0
+            exit 1
           fi
 
       - name: Issue a release only if a tag is based on a merged commit in `main` branch
@@ -28,7 +28,7 @@ jobs:
             echo "Tag is based on a merged commit in the main branch"
           else
             echo "Tag is not based on a merged commit in the main branch. Exiting."
-            exit 0
+            exit 1
           fi
 
       - name: Setup Java

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Release
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
+
 jobs:
   release-core:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,13 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
+      - name: Check tag name pattern follows `vX.Y.Z`
+        run: |
+          if [[ ! "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag name ($GITHUB_REF) does not match the pattern 'vX.Y.Z'. Exiting."
+            exit 0
+          fi
+
       - name: Issue a release only if a tag is based on a merged commit in `main` branch
         run: |
           tag_commit=$(git rev-parse ${{ github.ref }})
@@ -21,13 +28,6 @@ jobs:
             echo "Tag is based on a merged commit in the main branch"
           else
             echo "Tag is not based on a merged commit in the main branch. Exiting."
-            exit 0
-          fi
-
-      - name: Check tag name pattern follows `vX.Y.Z`
-        run: |
-          if [[ ! "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Tag name does not match the pattern 'vX.Y.Z'. Exiting."
             exit 0
           fi
 


### PR DESCRIPTION
Used to debug workflow not being triggered upon tags push. 

Turns out the problem comes from the fact that we're pushing tags on commits earlier than the `release` pipeline being merged. 
I've created a personal repo to test this and saw that:
- have two commits in main branch with the pipeline merged in the 2nd one
- tag first commit and push => no trigger
- tag last commit and push => release is triggered 

Here's a [GitHub discussion that verifies this](https://github.com/orgs/community/discussions/25963).