### PR TITLE
chore(release): fetch `main` to validate tag is from commit in said ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Issue a release only if a tag is based on a merged commit in `main` branch
         run: |
           tag_commit=$(git rev-parse ${{ github.ref }})
+
+          git fetch -f origin main
           merged_commit=$(git rev-parse main)
 
           if git merge-base --is-ancestor $tag_commit $merged_commit; then


### PR DESCRIPTION
Due to the way we checkout the code, only the triggering ref will be
available, thus `main` isn't known to the local git repo.
We add a `git fetch main` in the "ensure release happens on a commit
merged in main ref" validation step.

This is to resolve this pipeline error
https://github.com/bluegroundltd/transactional-outbox/actions/runs/7059863521/job/19218288143