### PR TITLE
chore(release): fetch all refs to validate commit on `main`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
+          # https://github.com/actions/checkout?tab=readme-ov-file#Fetch-all-history-for-all-tags-and-branches
+          fetch-depth: 0
           ref: ${{ github.ref }}
 
       - name: Check tag name pattern follows `vX.Y.Z`
@@ -23,9 +25,7 @@ jobs:
       - name: Issue a release only if a tag is based on a merged commit in `main` branch
         run: |
           tag_commit=$(git rev-parse ${{ github.ref }})
-
-          git fetch -f origin main
-          merged_commit=$(git rev-parse main)
+          merged_commit=$(git rev-parse origin/main)
 
           if git merge-base --is-ancestor $tag_commit $merged_commit; then
             echo "Tag is based on a merged commit in the main branch"


### PR DESCRIPTION
1.  Use `fetch-depth: 0` of checkout action to fetch all refs, as per this https://github.com/actions/checkout?tab=readme-ov-file#Fetch-all-history-for-all-tags-and-branches
2. Finally, use `git rev-parse origin/main` since we don't have a local `main` branch ref.

Tested it works [here](https://github.com/bluegroundltd/transactional-outbox/actions/runs/7060856731/job/19221256579#step:4:14). A failing pipeline, since the tag wasn't based on a commit merged in `main` ref.