### PR TITLE
feat: add locking in cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Transactional Outbox is published on `mavenCentral`. In order to use it just add
 
 ```gradle
 
-implementation("io.github.bluegroundltd:transactional-outbox-core:1.0.0")
+implementation("io.github.bluegroundltd:transactional-outbox-core:2.0.0")
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Transactional Outbox is a library that provides a simple way to implement
 the [Transactional Outbox Pattern](https://microservices.io/patterns/data/transactional-outbox.html) in your
 application, developed by Blueground.
 
-Api Docs: https://bluegroundltd.github.io/transactional-outbox/
+API Docs: https://bluegroundltd.github.io/transactional-outbox/
 
 ## Table of Contents
 
@@ -49,18 +49,20 @@ class OutboxConfiguration(
 
   @Bean
   fun transactionalOutbox(): TransactionalOutbox {
-    val locksProvider = OutboxLocksProvider(postgresLockDao, APPLICATION_SPECIFIC_ID)
+    val monitorLocksProvider = OutboxLocksProvider(postgresLockDao, MONITOR_APPLICATION_SPECIFIC_ID)
+    val cleanupLocksProvider = OutboxLocksProvider(postgresLockDao, CLEANUP_APPLICATION_SPECIFIC_ID)
 
     return TransactionalOutboxBuilder
       .make(clock)
       .withHandlers(outboxHandlers)
-      .withLocksProvider(locksProvider)
+      .withMonitorLocksProvider(monitorLocksProvider)
+      .withCleanupLocksProvider(cleanupLocksProvider)
       .withStore(outboxStore)
       .build()
   }
 }
 
-private class OutboxLocksProvider(
+private class OutboxLocksProviderImpl(
   private val postgresLockDao: PostgresLockDao,
   private val id: Long
 ) : OutboxLocksProvider {
@@ -76,7 +78,10 @@ private class OutboxLocksProvider(
 
 ### Creating a new Outbox Handler
 
-Then you can create a new `OutboxHandler` that will be responsible for processing the `Outbox` entries:
+Then you can create a new `OutboxHandler` that will be responsible for processing the `Outbox` entries.  
+Below you can see a barebones handler, but there's also a utility handler, which uses JSON (de)serialization and
+reduces the outbox handlers boilerplate code. Refer to [SimpleOutboxHandler](https://bluegroundltd.github.io/transactional-outbox/core/io.github.bluegroundltd.outbox/-simple-outbox-handler/index.html) in our [docs page](
+https://bluegroundltd.github.io/transactional-outbox/index.html).
 
 ```kotlin
 enum class MyOutboxType: OutboxType {

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,55 @@
+# Upgrade Guide
+
+## v.2.x.x
+
+### v.2.0.0 - Completed outbox items cleanup coordination
+
+Release 2.0.0 introduces coordination in the cleanup process across instances using locks.
+
+#### `TransactionalOutboxBuilder#withLocksProvider` has been removed in favor of `withMonitorLocksProvider`   
+The reason for this breaking change was the need to introduce a different locks provider for the completed outbox items cleanup process.  
+We could reuse the same locks provider for both the monitor and cleanup process, but this would entail serialized execution of the two processes, which was not desirable.    
+The requirement for the new locks provider is solely to be independent of the locks provider used in the monitor process.  
+For example, if the locks provider implementation is using Postgres advisory locks, the monitor and the cleanup locks should use a different lock identifier.
+
+**Required changes**  
+The `TransactionalOutboxBuilder` call needs to be updated from 
+```kotlin
+TransactionalOutboxBuilder
+  .make(clock)
+  .withHandlers(outboxHandlers)
+  .withLocksProvider(locksProvider)
+  .withStore(outboxStore)
+  .build()
+```
+to
+```kotlin
+TransactionalOutboxBuilder
+  .make(clock)
+  .withHandlers(outboxHandlers)
+  .withMonitorLocksProvider(PostgresOutboxLocksProvider(LOCKS_MONITOR_ID))
+  .withCleanupLocksProvider(PostgresOutboxLocksProvider(LOCKS_CLEANUP_ID))
+  .withStore(outboxStore)
+  .build()
+```
+N.B.: The above assumes that the locks provider implementation is using Postgres advisory locks.
+
+## v.1.x.x 
+
+### v.1.0.0 - Completed outbox items cleanup
+
+Release 1.0 introduces a cleanup process for the outbox items that have been successfully processed, thus reducing the size of the outbox table, which can grow quite large.  
+When the outbox items are processes successfully, in addition to be marked as completed, their `OutboxItem.deleteAfter` field is set to `now() + retentionPeriod`.  
+The cleanup process, like monitor, should be run periodically, depending on your needs. Once run, it deletes the completed
+outbox items whose `deleteAfter` is earlier than the current time.
+
+It is advisable to manually delete the already completed outbox items before upgrading to 1.0.0, as the cleanup process
+will issue a deletion, which may be quite heavy in terms of I/O operations, hence timeouts may occur on the first run.
+
+**Required changes**  
+In the `OutboxStore` implementing class, the `deleteCompletedItems(now: Instant)` method needs to be implemented.
+The method should simply delete the outbox items with status `COMPLETED` with a `deleteAfter` earlier than the provided `now` parameter.
+
+Finally, the retention duration period can be defined per outbox handler for flexibility.  
+A new `OutboxHandler` method has been added `getRetentionDuration(): Duration` which should return the retention period for the outbox items of the handler.  
+Feel free to look the [SimpleOutboxHandler](./core/src/main/kotlin/io/github/bluegroundltd/outbox/SimpleOutboxHandler.kt) for an example.

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=io.github.bluegroundltd
 POM_ARTIFACT_ID=transactional-outbox-core
-VERSION_NAME=1.0.0
+VERSION_NAME=2.0.0
 
 POM_NAME=Transactional Outbox Core
 POM_DESCRIPTION=Easily implement the transactional outbox pattern in your JVM application

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxAddSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxAddSpec.groovy
@@ -22,7 +22,8 @@ class OutboxAddSpec extends UnitTestSpecification {
   private static final Duration DURATION_ONE_HOUR = Duration.ofHours(1)
   Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())
   Map<OutboxType, OutboxHandler> handlers = Mock()
-  OutboxLocksProvider locksProvider = Mock()
+  OutboxLocksProvider monitorLocksProvider = Mock()
+  OutboxLocksProvider cleanupLocksProvider = Mock()
   OutboxStore store = Mock()
   InstantOutboxPublisher instantOutboxPublisher = Mock()
   OutboxItemFactory outboxItemFactory = Mock()
@@ -34,7 +35,8 @@ class OutboxAddSpec extends UnitTestSpecification {
     transactionalOutbox = new TransactionalOutboxImpl(
       clock,
       handlers,
-      locksProvider,
+      monitorLocksProvider,
+      cleanupLocksProvider,
       store,
       instantOutboxPublisher,
       outboxItemFactory,

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxShutdownSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxShutdownSpec.groovy
@@ -25,7 +25,8 @@ class OutboxShutdownSpec extends Specification {
   private static final Duration DURATION_ONE_HOUR = Duration.ofHours(1)
   Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())
   Map<OutboxType, OutboxHandler> handlers = Mock()
-  OutboxLocksProvider locksProvider = Mock()
+  OutboxLocksProvider monitorLocksProvider = Mock()
+  OutboxLocksProvider cleanupLocksProvider = Mock()
   OutboxStore store = Mock()
   InstantOutboxPublisher instantOutboxPublisher = Mock()
   OutboxItemFactory outboxItemFactory = Mock()
@@ -37,7 +38,8 @@ class OutboxShutdownSpec extends Specification {
     transactionalOutbox = new TransactionalOutboxImpl(
       clock,
       handlers,
-      locksProvider,
+      monitorLocksProvider,
+      cleanupLocksProvider,
       store,
       instantOutboxPublisher,
       outboxItemFactory,

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/TransactionalOutboxBuilderSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/TransactionalOutboxBuilderSpec.groovy
@@ -10,7 +10,6 @@ import io.github.bluegroundltd.outbox.item.OutboxType
 import io.github.bluegroundltd.outbox.store.OutboxStore
 import io.github.bluegroundltd.outbox.utils.DummyOutboxHandler
 import io.github.bluegroundltd.outbox.utils.UnitTestSpecification
-import spock.lang.Unroll
 
 import java.time.Clock
 import java.time.Duration
@@ -19,11 +18,11 @@ import java.time.ZoneId
 
 class TransactionalOutboxBuilderSpec extends UnitTestSpecification {
   def clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())
-  def locksProvider = GroovyMock(OutboxLocksProvider)
+  def monitorLocksProvider = GroovyMock(OutboxLocksProvider)
+  def cleanupLocksProvider = GroovyMock(OutboxLocksProvider)
   def store = GroovyMock(OutboxStore)
   def instantOutboxPublisher = GroovyMock(InstantOutboxPublisher)
 
-  @Unroll
   def "Should build a transactional outbox instance #testCase"() {
     given:
       def builder = TransactionalOutboxBuilder.make(clock)
@@ -39,7 +38,8 @@ class TransactionalOutboxBuilderSpec extends UnitTestSpecification {
     when:
       def transactionalOutboxBuilder = builder
         .withHandlers(handlers)
-        .withLocksProvider(locksProvider)
+        .withMonitorLocksProvider(monitorLocksProvider)
+        .withCleanupLocksProvider(cleanupLocksProvider)
         .withStore(store)
         .withInstantOutboxPublisher(instantOutboxPublisher)
 
@@ -84,7 +84,8 @@ class TransactionalOutboxBuilderSpec extends UnitTestSpecification {
     when:
       builder
         .withHandlers(handlers)
-        .withLocksProvider(locksProvider)
+        .withMonitorLocksProvider(monitorLocksProvider)
+        .withCleanupLocksProvider(cleanupLocksProvider)
         .withStore(store)
         .withInstantOutboxPublisher(instantOutboxPublisher)
         .build()


### PR DESCRIPTION
Continuation of the outbox items cleanup epic. As per our [spike](https://devblueground.atlassian.net/browse/VR-3914), we've introduced a separate locks provider for cleanup. Please refer to the commit message for the rationale behind this. 

Resolves [[VR-3403](https://devblueground.atlassian.net/browse/VR-3403)].


[VR-3403]: https://devblueground.atlassian.net/browse/VR-3403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ