### PR TITLE
[SW-587] Introduce outbox item groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Transactional Outbox is published on `mavenCentral`. In order to use it just add
 
 ```gradle
 
-implementation("io.github.bluegroundltd:transactional-outbox-core:2.0.2")
+implementation("io.github.bluegroundltd:transactional-outbox-core:2.0.3")
 
 ```
 

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=io.github.bluegroundltd
 POM_ARTIFACT_ID=transactional-outbox-core
-VERSION_NAME=2.0.2
+VERSION_NAME=2.0.3
 
 POM_NAME=Transactional Outbox Core
 POM_DESCRIPTION=Easily implement the transactional outbox pattern in your JVM application

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxGroupProcessor.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxGroupProcessor.kt
@@ -1,0 +1,36 @@
+package io.github.bluegroundltd.outbox
+
+import io.github.bluegroundltd.outbox.annotation.TestableOpenClass
+import io.github.bluegroundltd.outbox.item.OutboxItem
+import io.github.bluegroundltd.outbox.item.OutboxItemGroup
+import io.github.bluegroundltd.outbox.store.OutboxStore
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.time.Clock
+
+@TestableOpenClass
+internal class OutboxGroupProcessor(
+  itemGroup: OutboxItemGroup,
+  private val handlerResolver: (item: OutboxItem) -> OutboxHandler?,
+  private val store: OutboxStore,
+  private val clock: Clock,
+) : OutboxProcessingAction {
+  companion object {
+    private const val LOGGER_PREFIX = "[OUTBOX-GROUP-PROCESSOR]"
+    private val logger: Logger = LoggerFactory.getLogger(OutboxGroupProcessor::class.java)
+  }
+
+  private val itemProcessors: List<OutboxItemProcessor> = itemGroup.items.map {
+    OutboxItemProcessor(it, handlerResolver, store, clock)
+  }
+
+  override fun run() {
+    logger.info("$LOGGER_PREFIX Processing group with ${itemProcessors.size} items")
+    itemProcessors.forEach { it.run() }
+  }
+
+  override fun reset() {
+    logger.info("$LOGGER_PREFIX Resetting group with ${itemProcessors.size} items")
+    itemProcessors.forEach { it.reset() }
+  }
+}

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxItemProcessor.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxItemProcessor.kt
@@ -17,13 +17,13 @@ internal class OutboxItemProcessor(
   private val handler: OutboxHandler,
   private val store: OutboxStore,
   private val clock: Clock,
-) {
+) : OutboxProcessingAction {
   companion object {
     private const val LOGGER_PREFIX = "[OUTBOX-ITEM-PROCESSOR]"
     private val logger: Logger = LoggerFactory.getLogger(OutboxItemProcessor::class.java)
   }
 
-  fun run() {
+  override fun run() {
     if (!handler.supports(item.type)) {
       logger.error("$LOGGER_PREFIX Handler ${handler::class.java} does not support item of type: ${item.type}")
       throw InvalidOutboxHandlerException(item)
@@ -73,7 +73,7 @@ internal class OutboxItemProcessor(
    * that are unrelated to concurrency, but we should consider the cost of introducing such a mechanism
    * against the rarity of the occurrence and the limited nature of its effect.
    */
-  fun reset() {
+  override fun reset() {
     if (item.status == OutboxStatus.RUNNING) {
       logger.info("$LOGGER_PREFIX Resetting outbox item with id: ${item.id} to PENDING")
       item.status = OutboxStatus.PENDING

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxProcessingAction.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxProcessingAction.kt
@@ -1,0 +1,15 @@
+package io.github.bluegroundltd.outbox
+
+/**
+ * A 'runnable' action that will be executed in order to process outbox item(s).
+ *
+ * Encapsulates both the logic for processing items and the item(s) themselves along with any
+ * supporting components (e.g. handler(s), storage, etc.).
+ *
+ * It is expected that an instance of this interface will be created for each processing action,
+ * and it will be run inside an [OutboxProcessingHost].
+ */
+internal interface OutboxProcessingAction {
+  fun run()
+  fun reset()
+}

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxProcessingHost.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxProcessingHost.kt
@@ -5,7 +5,7 @@ import io.github.bluegroundltd.outbox.annotation.TestableOpenClass
 /**
  * Serves as a host inside which outbox items will be processed.
  *
- * @param processor the processor that will be used to process the outbox items
+ * @param processingAction the processing action that will be run to process the outbox items
  * @param decorators a list of decorators that will be used to decorate the processor
  *
  * This component allows for separating the responsibilities of processing the items and being scheduled
@@ -20,15 +20,15 @@ import io.github.bluegroundltd.outbox.annotation.TestableOpenClass
 @Suppress("TooGenericExceptionCaught")
 @TestableOpenClass
 internal class OutboxProcessingHost(
-  private val processor: OutboxItemProcessor,
+  private val processingAction: OutboxProcessingAction,
   decorators: List<OutboxItemProcessorDecorator>
 ) : Runnable {
 
   private val processorRunnable = Runnable {
     try {
-      processor.run()
+      processingAction.run()
     } catch (e: Exception) {
-      processor.reset()
+      processingAction.reset()
     }
   }
   private val finalRunnable: Runnable = decorators
@@ -39,6 +39,6 @@ internal class OutboxProcessingHost(
   }
 
   fun reset() {
-    processor.reset()
+    processingAction.reset()
   }
 }

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxProcessingHostBuilder.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxProcessingHostBuilder.kt
@@ -1,0 +1,18 @@
+package io.github.bluegroundltd.outbox
+
+import io.github.bluegroundltd.outbox.annotation.TestableOpenClass
+
+/**
+ * Builds an [OutboxProcessingHost] instance.
+ *
+ * The main purpose of this component is to enhance/simplify testing since it allows for mocking the instances
+ * that are submitted to the executor. Accordingly, a lot of the unit tests have been adapted to make use of this
+ * functionality.
+ */
+@TestableOpenClass
+internal class OutboxProcessingHostBuilder {
+  fun build(
+    processingAction: OutboxProcessingAction,
+    decorators: List<OutboxItemProcessorDecorator>
+  ) = OutboxProcessingHost(processingAction, decorators)
+}

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxProcessingHostComposer.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxProcessingHostComposer.kt
@@ -3,15 +3,15 @@ package io.github.bluegroundltd.outbox
 import io.github.bluegroundltd.outbox.annotation.TestableOpenClass
 
 /**
- * Builds an [OutboxProcessingHost] instance.
+ * Composes an [OutboxProcessingHost] instance.
  *
  * The main purpose of this component is to enhance/simplify testing since it allows for mocking the instances
  * that are submitted to the executor. Accordingly, a lot of the unit tests have been adapted to make use of this
  * functionality.
  */
 @TestableOpenClass
-internal class OutboxProcessingHostBuilder {
-  fun build(
+internal class OutboxProcessingHostComposer {
+  fun compose(
     processingAction: OutboxProcessingAction,
     decorators: List<OutboxItemProcessorDecorator>
   ) = OutboxProcessingHost(processingAction, decorators)

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutboxBuilder.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutboxBuilder.kt
@@ -171,7 +171,8 @@ class TransactionalOutboxBuilder(
         rerunAfterDuration,
         executorServiceFactory.make(),
         decorators,
-        threadPoolTimeOut
+        threadPoolTimeOut,
+        OutboxProcessingHostBuilder()
     )
   }
 }

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutboxBuilder.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutboxBuilder.kt
@@ -172,7 +172,7 @@ class TransactionalOutboxBuilder(
         executorServiceFactory.make(),
         decorators,
         threadPoolTimeOut,
-        OutboxProcessingHostBuilder()
+        OutboxProcessingHostComposer()
     )
   }
 }

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutboxImpl.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutboxImpl.kt
@@ -3,6 +3,7 @@ package io.github.bluegroundltd.outbox
 import io.github.bluegroundltd.outbox.event.InstantOutboxEvent
 import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher
 import io.github.bluegroundltd.outbox.item.OutboxItem
+import io.github.bluegroundltd.outbox.item.OutboxItemGroup
 import io.github.bluegroundltd.outbox.item.OutboxPayload
 import io.github.bluegroundltd.outbox.item.OutboxStatus
 import io.github.bluegroundltd.outbox.item.OutboxType
@@ -132,7 +133,7 @@ internal class TransactionalOutboxImpl(
   }
 
   private fun makeOutboxProcessor(item: OutboxItem): OutboxProcessingAction =
-    OutboxItemProcessor(item, ::resolveOutboxHandler, outboxStore, clock)
+    OutboxGroupProcessor(OutboxItemGroup(listOf(item)), ::resolveOutboxHandler, outboxStore, clock)
 
   private fun resolveOutboxHandler(item: OutboxItem): OutboxHandler? = outboxHandlers[item.type]
 

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/item/OutboxItemGroup.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/item/OutboxItemGroup.kt
@@ -1,0 +1,5 @@
+package io.github.bluegroundltd.outbox.item
+
+data class OutboxItemGroup(
+  val items: List<OutboxItem>
+) : Iterable<OutboxItem> by items

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
@@ -7,11 +7,19 @@ import io.github.bluegroundltd.outbox.TransactionalOutbox
 import io.github.bluegroundltd.outbox.TransactionalOutboxImpl
 import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher
 import io.github.bluegroundltd.outbox.executor.FixedThreadPoolExecutorServiceFactory
+import io.github.bluegroundltd.outbox.item.OutboxItem
+import io.github.bluegroundltd.outbox.item.OutboxStatus
 import io.github.bluegroundltd.outbox.item.OutboxType
 import io.github.bluegroundltd.outbox.item.factory.OutboxItemFactory
-import io.github.bluegroundltd.outbox.store.OutboxStore
-import io.github.bluegroundltd.outbox.utils.DelayingOutboxHandler
+import io.github.bluegroundltd.outbox.utils.DummyOutboxHandler
+import io.github.bluegroundltd.outbox.utils.DummyOutboxType
+import io.github.bluegroundltd.outbox.utils.FailingOutboxHandler
+import io.github.bluegroundltd.outbox.utils.InMemoryOutboxStore
+import io.github.bluegroundltd.outbox.utils.MockOutboxHandler
+import io.github.bluegroundltd.outbox.utils.OutboxItemBuilder
+import io.github.bluegroundltd.outbox.utils.SimpleOutboxType
 import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
 
 import java.time.Clock
 import java.time.Duration
@@ -19,38 +27,90 @@ import java.time.Instant
 import java.time.ZoneId
 
 class TransactionalOutboxImplSpec extends Specification {
-  private static final Duration DURATION_ONE_HOUR = Duration.ofHours(1)
-  private static final Duration DURATION_ONE_NANO = Duration.ofNanos(1)
-  private static final Clock CLOCK = Clock.fixed(Instant.now(), ZoneId.systemDefault())
+  private final static Duration DURATION_ONE_HOUR = Duration.ofHours(1)
+  private final static Duration DURATION_ONE_NANO = Duration.ofNanos(1)
+  private final static Clock CLOCK = Clock.fixed(Instant.now(), ZoneId.systemDefault())
 
-  private OutboxHandler handler = new DelayingOutboxHandler(CLOCK)
-  private OutboxType type = handler.getSupportedType()
-  private Map<OutboxType, OutboxHandler> handlers = Map.of(type, handler)
+  private final static OutboxHandler DUMMY_HANDLER =
+    new DummyOutboxHandler(CLOCK)
+  private final static OutboxHandler SUCCEEDING_HANDLER =
+    new MockOutboxHandler(new SimpleOutboxType("succeeding"), CLOCK)
+  private final static OutboxHandler RETRYABLE_FAILURE_HANDLER =
+    new FailingOutboxHandler(new SimpleOutboxType("retryableFailure"), CLOCK, false)
+  private final static OutboxHandler TERMINAL_FAILURE_HANDLER =
+    new FailingOutboxHandler(new SimpleOutboxType("terminalFailure"), CLOCK, true)
+  private final static List<OutboxHandler> HANDLERS =
+    [DUMMY_HANDLER, SUCCEEDING_HANDLER, RETRYABLE_FAILURE_HANDLER, TERMINAL_FAILURE_HANDLER]
+  private final static Map<OutboxType, OutboxHandler> HANDLER_MAP =
+    HANDLERS.collectEntries { [it.getSupportedType(), it] }
 
-  private OutboxLocksProvider monitorLocksProvider = Mock()
-  private OutboxLocksProvider cleanupLocksProvider = Mock()
-  private OutboxStore store = Mock()
-  private InstantOutboxPublisher instantOutboxPublisher = Mock()
-  private OutboxItemFactory outboxItemFactory = Mock()
-  private OutboxProcessingHostBuilder processingHostBuilder = Mock()
+  private final OutboxLocksProvider monitorLocksProvider = Mock()
+  private final OutboxLocksProvider cleanupLocksProvider = Mock()
+  private final InMemoryOutboxStore store = new InMemoryOutboxStore()
+  private final InstantOutboxPublisher instantOutboxPublisher = Mock()
+  private final OutboxItemFactory outboxItemFactory = Mock()
+  private final OutboxProcessingHostBuilder processingHostBuilder = new OutboxProcessingHostBuilder()
 
-  private TransactionalOutbox transactionalOutbox
+  private final TransactionalOutbox transactionalOutbox = new TransactionalOutboxImpl(
+    CLOCK,
+    HANDLER_MAP,
+    monitorLocksProvider,
+    cleanupLocksProvider,
+    store,
+    instantOutboxPublisher,
+    outboxItemFactory,
+    DURATION_ONE_HOUR,
+    new FixedThreadPoolExecutorServiceFactory(1, "").make(),
+    [],
+    DURATION_ONE_NANO,
+    processingHostBuilder
+  )
 
-  def setup() {
-    transactionalOutbox = new TransactionalOutboxImpl(
-      CLOCK,
-      handlers,
-      monitorLocksProvider,
-      cleanupLocksProvider,
-      store,
-      instantOutboxPublisher,
-      outboxItemFactory,
-      DURATION_ONE_HOUR,
-      new FixedThreadPoolExecutorServiceFactory(1, "").make(),
-      [],
-      DURATION_ONE_NANO,
-      processingHostBuilder
-    )
+  def "Should process all eligible items when [monitor] is invoked and set their statuses to 'COMPLETED'"() {
+    given:
+      def items = (1..5).collect { makePendingOutboxItem() }
+      items.forEach { store.insert(it) }
+
+    when:
+      transactionalOutbox.monitor()
+
+    then:
+      1 * monitorLocksProvider.acquire()
+      1 * monitorLocksProvider.release()
+      0 * _
+
+    and:
+      new PollingConditions(timeout: 10, delay: 0.5).eventually {
+        def updatedItems = store.get(items.collect { it.id })
+        updatedItems.each {
+          assert it.status == OutboxStatus.COMPLETED
+        }
+      }
+  }
+
+  def "Should appropriately set the status of all processed items when [monitor] is invoked"() {
+    given: "Some items of various types"
+      def itemsWithSucceedingType = (1..2).collect { makePendingOutboxItem(SUCCEEDING_HANDLER.getSupportedType()) }
+      def itemsWithRetryableFailureType = (1..2).collect { makePendingOutboxItem(RETRYABLE_FAILURE_HANDLER.getSupportedType()) }
+      def itemsWithTerminalFailureType = (1..2).collect { makePendingOutboxItem(TERMINAL_FAILURE_HANDLER.getSupportedType()) }
+      def items = itemsWithSucceedingType + itemsWithRetryableFailureType + itemsWithTerminalFailureType
+      items.forEach { store.insert(it) }
+
+    when:
+      transactionalOutbox.monitor()
+
+    then:
+      1 * monitorLocksProvider.acquire()
+      1 * monitorLocksProvider.release()
+      0 * _
+
+    and:
+      new PollingConditions(timeout: 10, delay: 0.5).eventually {
+        def updatedItems = store.get(items.collect { it.id })
+        updatedItems.each {
+          assert it.status == expectedStatus(it)
+        }
+      }
   }
 
   def "Should early return from cleanup if in shutdown mode"() {
@@ -60,5 +120,22 @@ class TransactionalOutboxImplSpec extends Specification {
 
     then:
       0 * _
+  }
+
+  private final static OutboxItem makePendingOutboxItem(OutboxType type = null) {
+    OutboxItemBuilder.make().withType(type ?: new DummyOutboxType()).withStatus(OutboxStatus.PENDING).build()
+  }
+
+  private final static OutboxStatus expectedStatus(OutboxItem item) {
+    switch (item.type) {
+      case SUCCEEDING_HANDLER.getSupportedType():
+        return OutboxStatus.COMPLETED
+      case RETRYABLE_FAILURE_HANDLER.getSupportedType():
+        return OutboxStatus.PENDING
+      case TERMINAL_FAILURE_HANDLER.getSupportedType():
+        return OutboxStatus.FAILED
+      default:
+        return null
+    }
   }
 }

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
@@ -2,7 +2,7 @@ package io.github.bluegroundltd.outbox.integration
 
 import io.github.bluegroundltd.outbox.OutboxHandler
 import io.github.bluegroundltd.outbox.OutboxLocksProvider
-import io.github.bluegroundltd.outbox.OutboxProcessingHostBuilder
+import io.github.bluegroundltd.outbox.OutboxProcessingHostComposer
 import io.github.bluegroundltd.outbox.TransactionalOutbox
 import io.github.bluegroundltd.outbox.TransactionalOutboxImpl
 import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher
@@ -49,7 +49,7 @@ class TransactionalOutboxImplSpec extends Specification {
   private final InMemoryOutboxStore store = new InMemoryOutboxStore()
   private final InstantOutboxPublisher instantOutboxPublisher = Mock()
   private final OutboxItemFactory outboxItemFactory = Mock()
-  private final OutboxProcessingHostBuilder processingHostBuilder = new OutboxProcessingHostBuilder()
+  private final OutboxProcessingHostComposer processingHostComposer = new OutboxProcessingHostComposer()
 
   private final TransactionalOutbox transactionalOutbox = new TransactionalOutboxImpl(
     CLOCK,
@@ -63,7 +63,7 @@ class TransactionalOutboxImplSpec extends Specification {
     new FixedThreadPoolExecutorServiceFactory(1, "").make(),
     [],
     DURATION_ONE_NANO,
-    processingHostBuilder
+    processingHostComposer
   )
 
   def "Should process all eligible items when [monitor] is invoked and set their statuses to 'COMPLETED'"() {

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
@@ -10,7 +10,7 @@ import io.github.bluegroundltd.outbox.executor.FixedThreadPoolExecutorServiceFac
 import io.github.bluegroundltd.outbox.item.OutboxType
 import io.github.bluegroundltd.outbox.item.factory.OutboxItemFactory
 import io.github.bluegroundltd.outbox.store.OutboxStore
-import io.github.bluegroundltd.outbox.utils.DummyHandler
+import io.github.bluegroundltd.outbox.utils.DelayingOutboxHandler
 import spock.lang.Specification
 
 import java.time.Clock
@@ -23,7 +23,7 @@ class TransactionalOutboxImplSpec extends Specification {
   private static final Duration DURATION_ONE_NANO = Duration.ofNanos(1)
   private static final Clock CLOCK = Clock.fixed(Instant.now(), ZoneId.systemDefault())
 
-  private OutboxHandler handler = new DummyHandler()
+  private OutboxHandler handler = new DelayingOutboxHandler(CLOCK)
   private OutboxType type = handler.getSupportedType()
   private Map<OutboxType, OutboxHandler> handlers = Map.of(type, handler)
 

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
@@ -2,6 +2,7 @@ package io.github.bluegroundltd.outbox.integration
 
 import io.github.bluegroundltd.outbox.OutboxHandler
 import io.github.bluegroundltd.outbox.OutboxLocksProvider
+import io.github.bluegroundltd.outbox.OutboxProcessingHostBuilder
 import io.github.bluegroundltd.outbox.TransactionalOutbox
 import io.github.bluegroundltd.outbox.TransactionalOutboxImpl
 import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher
@@ -31,6 +32,7 @@ class TransactionalOutboxImplSpec extends Specification {
   private OutboxStore store = Mock()
   private InstantOutboxPublisher instantOutboxPublisher = Mock()
   private OutboxItemFactory outboxItemFactory = Mock()
+  private OutboxProcessingHostBuilder processingHostBuilder = Mock()
 
   private TransactionalOutbox transactionalOutbox
 
@@ -46,7 +48,8 @@ class TransactionalOutboxImplSpec extends Specification {
       DURATION_ONE_HOUR,
       new FixedThreadPoolExecutorServiceFactory(1, "").make(),
       [],
-      DURATION_ONE_NANO
+      DURATION_ONE_NANO,
+      processingHostBuilder
     )
   }
 

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxAddSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxAddSpec.groovy
@@ -2,6 +2,7 @@ package io.github.bluegroundltd.outbox.unit
 
 import io.github.bluegroundltd.outbox.OutboxHandler
 import io.github.bluegroundltd.outbox.OutboxLocksProvider
+import io.github.bluegroundltd.outbox.OutboxProcessingHostBuilder
 import io.github.bluegroundltd.outbox.TransactionalOutbox
 import io.github.bluegroundltd.outbox.TransactionalOutboxImpl
 import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher
@@ -29,6 +30,7 @@ class OutboxAddSpec extends UnitTestSpecification {
   OutboxItemFactory outboxItemFactory = Mock()
   ExecutorService executor = Mock()
   Duration threadPoolTimeOut = Duration.ofMillis(5000)
+  OutboxProcessingHostBuilder processingHostBuilder = Mock()
   TransactionalOutbox transactionalOutbox
 
   def setup() {
@@ -43,7 +45,8 @@ class OutboxAddSpec extends UnitTestSpecification {
       DURATION_ONE_HOUR,
       executor,
       [],
-      threadPoolTimeOut
+      threadPoolTimeOut,
+      processingHostBuilder
     )
   }
 

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxAddSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxAddSpec.groovy
@@ -2,7 +2,7 @@ package io.github.bluegroundltd.outbox.unit
 
 import io.github.bluegroundltd.outbox.OutboxHandler
 import io.github.bluegroundltd.outbox.OutboxLocksProvider
-import io.github.bluegroundltd.outbox.OutboxProcessingHostBuilder
+import io.github.bluegroundltd.outbox.OutboxProcessingHostComposer
 import io.github.bluegroundltd.outbox.TransactionalOutbox
 import io.github.bluegroundltd.outbox.TransactionalOutboxImpl
 import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher
@@ -30,7 +30,7 @@ class OutboxAddSpec extends UnitTestSpecification {
   OutboxItemFactory outboxItemFactory = Mock()
   ExecutorService executor = Mock()
   Duration threadPoolTimeOut = Duration.ofMillis(5000)
-  OutboxProcessingHostBuilder processingHostBuilder = Mock()
+  OutboxProcessingHostComposer processingHostComposer = Mock()
   TransactionalOutbox transactionalOutbox
 
   def setup() {
@@ -46,7 +46,7 @@ class OutboxAddSpec extends UnitTestSpecification {
       executor,
       [],
       threadPoolTimeOut,
-      processingHostBuilder
+      processingHostComposer
     )
   }
 

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxCleanupSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxCleanupSpec.groovy
@@ -1,7 +1,7 @@
 package io.github.bluegroundltd.outbox.unit
 
 import io.github.bluegroundltd.outbox.OutboxLocksProvider
-import io.github.bluegroundltd.outbox.OutboxProcessingHostBuilder
+import io.github.bluegroundltd.outbox.OutboxProcessingHostComposer
 import io.github.bluegroundltd.outbox.TransactionalOutbox
 import io.github.bluegroundltd.outbox.TransactionalOutboxImpl
 import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher
@@ -37,7 +37,7 @@ class OutboxCleanupSpec extends Specification {
     Mock(ExecutorService),
     [],
     Duration.ofMillis(5000),
-    Mock(OutboxProcessingHostBuilder)
+    Mock(OutboxProcessingHostComposer)
   )
 
   def "Should acquire the clean up lock, delete all completed items and release it"() {

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxCleanupSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxCleanupSpec.groovy
@@ -1,0 +1,97 @@
+package io.github.bluegroundltd.outbox.unit
+
+import io.github.bluegroundltd.outbox.OutboxLocksProvider
+import io.github.bluegroundltd.outbox.OutboxProcessingHostBuilder
+import io.github.bluegroundltd.outbox.TransactionalOutbox
+import io.github.bluegroundltd.outbox.TransactionalOutboxImpl
+import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher
+import io.github.bluegroundltd.outbox.item.factory.OutboxItemFactory
+import io.github.bluegroundltd.outbox.store.OutboxStore
+import spock.lang.Specification
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.util.concurrent.ExecutorService
+
+class OutboxCleanupSpec extends Specification {
+  private static final Duration DURATION_ONE_HOUR = Duration.ofHours(1)
+
+  private final Clock clock = Clock.fixed(Instant.now(), ZoneId.of("UTC"))
+  private final Instant now = Instant.now(clock)
+
+  private final OutboxLocksProvider monitorLocksProvider = Mock()
+  private final OutboxLocksProvider cleanupLocksProvider = Mock()
+  private final OutboxStore store = Mock()
+
+  private final TransactionalOutbox transactionalOutbox = new TransactionalOutboxImpl(
+    clock,
+    [:],
+    monitorLocksProvider,
+    cleanupLocksProvider,
+    store,
+    Mock(InstantOutboxPublisher),
+    Mock(OutboxItemFactory),
+    DURATION_ONE_HOUR,
+    Mock(ExecutorService),
+    [],
+    Duration.ofMillis(5000),
+    Mock(OutboxProcessingHostBuilder)
+  )
+
+  def "Should acquire the clean up lock, delete all completed items and release it"() {
+    when:
+      transactionalOutbox.cleanup()
+
+    then:
+      1 * cleanupLocksProvider.acquire()
+      1 * store.deleteCompletedItems(now)
+      1 * cleanupLocksProvider.release()
+      0 * _
+  }
+
+  def "Should do nothing when it fails to acquire the cleanup lock"() {
+    when:
+      transactionalOutbox.cleanup()
+
+    then:
+      1 * cleanupLocksProvider.acquire() >> {
+        throw new InterruptedException()
+      }
+      0 * _
+      noExceptionThrown()
+  }
+
+  def "Should handle an exception thrown when deleting the completed items"() {
+    when:
+      transactionalOutbox.cleanup()
+
+    then:
+      1 * cleanupLocksProvider.acquire()
+      1 * store.deleteCompletedItems(now) >> {
+        throw new InterruptedException()
+      }
+      1 * cleanupLocksProvider.release()
+      0 * _
+
+    and:
+      noExceptionThrown()
+  }
+
+  def "Should handle an exception thrown when releasing the cleanup lock"() {
+    when:
+      transactionalOutbox.cleanup()
+
+    then:
+      1 * cleanupLocksProvider.acquire()
+      1 * store.deleteCompletedItems(now)
+      1 * cleanupLocksProvider.release() >> {
+        throw new InterruptedException()
+      }
+      0 * _
+
+    and:
+      noExceptionThrown()
+  }
+}

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxGroupProcessorSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxGroupProcessorSpec.groovy
@@ -1,0 +1,170 @@
+package io.github.bluegroundltd.outbox.unit
+
+import io.github.bluegroundltd.outbox.OutboxGroupProcessor
+import io.github.bluegroundltd.outbox.OutboxHandler
+import io.github.bluegroundltd.outbox.item.OutboxItem
+import io.github.bluegroundltd.outbox.item.OutboxItemGroup
+import io.github.bluegroundltd.outbox.item.OutboxStatus
+import io.github.bluegroundltd.outbox.store.OutboxStore
+import io.github.bluegroundltd.outbox.utils.OutboxItemBuilder
+import spock.lang.Specification
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+
+class OutboxGroupProcessorSpec extends Specification {
+  private final Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())
+  private final Instant now = Instant.now(clock)
+
+  private final outboxItems = (1..5).collect {
+    OutboxItemBuilder.make().withStatus(OutboxStatus.RUNNING).build()
+  }
+  private final Map<Long, OutboxHandler> outboxHandlers = outboxItems.collectEntries {
+    [(it.id): Mock(OutboxHandler)]
+  }
+  private final outboxItemGroup = new OutboxItemGroup(outboxItems)
+
+  private Long failingItemId = null // Allows for dynamically setting a handler resolution to fail.
+  private final handlerResolutionException = new RuntimeException("Handler could not be resolved")
+  private final handlerResolver = { OutboxItem item ->
+    if (item.id == failingItemId) {
+      throw handlerResolutionException
+    }
+    return outboxHandlers[item.id]
+  }
+  private final OutboxStore store = GroovyMock()
+
+  private final OutboxGroupProcessor processor = new OutboxGroupProcessor(
+    outboxItemGroup,
+    handlerResolver,
+    store,
+    clock
+  )
+
+  def "Should process all items in the group when [run] is invoked"() {
+    when:
+      processor.run()
+
+    then:
+      outboxItems.each {
+        def handler = outboxHandlers[it.id]
+        def retentionDuration = Duration.ofDays(10)
+
+        1 * handler.getSupportedType() >> it.type
+        1 * handler.handle(it.payload)
+        1 * handler.getRetentionDuration() >> retentionDuration
+        1 * store.update(_) >> { OutboxItem item ->
+          // For proper verification see [OutboxItemProcessorSpec].
+          assert item.id == it.id
+          item
+        }
+      }
+      0 * _
+  }
+
+  def "Should propagate any exception thrown when processing items"() {
+    given:
+      def successfullyProcessedCount = 2
+      def processedItems = outboxItems.take(successfullyProcessedCount)
+      def failingItem = outboxItems[successfullyProcessedCount]
+      def notProcessedItems = outboxItems - processedItems - failingItem
+
+    and: "Setting up handler resolution failure"
+      failingItemId = failingItem.id
+
+    when:
+      processor.run()
+
+    then:
+      processedItems.each {
+        def handler = outboxHandlers[it.id]
+
+        1 * handler.getSupportedType() >> it.type
+        1 * handler.handle(it.payload)
+        1 * handler.getRetentionDuration() >> Duration.ofDays(10)
+        1 * store.update(_) >> { OutboxItem item ->
+          // For proper verification see [OutboxItemProcessorSpec].
+          assert item.id == it.id
+          item
+        }
+      }
+      0 * _
+
+    and:
+      def ex = thrown(RuntimeException)
+      ex == handlerResolutionException
+
+    and:
+      processedItems.each {
+        assert it.status == OutboxStatus.COMPLETED
+      }
+      assert failingItem.status == OutboxStatus.RUNNING // The exception was thrown before it's status was updated.
+      notProcessedItems.each {
+        assert it.status == OutboxStatus.RUNNING
+      }
+  }
+
+  def "Should reset all items in the group when [reset] is invoked"() {
+    when:
+      processor.reset()
+
+    then:
+      outboxItems.each {
+        1 * store.update(_) >> { OutboxItem item ->
+          // For proper verification see [OutboxItemProcessorSpec].
+          assert item.id == it.id
+          item
+        }
+      }
+      0 * _
+
+    and:
+      outboxItems.each {
+        assert it.status == OutboxStatus.PENDING
+      }
+  }
+
+  def "Should propagate any exception thrown when resetting items"() {
+    given:
+      def successfullyResetCount = 2
+      def resetItems = outboxItems.take(successfullyResetCount)
+      def failingItem = outboxItems[successfullyResetCount]
+      def notResetItems = outboxItems - resetItems - failingItem
+
+    and:
+      def exception = new RuntimeException("Reset failed")
+
+    when:
+      processor.reset()
+
+    then:
+      resetItems.each {
+        1 * store.update(_) >> { OutboxItem item ->
+          // For proper verification see [OutboxItemProcessorSpec].
+          assert item.id == it.id
+          item
+        }
+      }
+      1 * store.update(_) >> { OutboxItem item ->
+        // For proper verification see [OutboxItemProcessorSpec].
+        assert item.id == failingItem.id
+        throw exception
+      }
+      0 * _
+
+    and:
+      def ex = thrown(RuntimeException)
+      ex == exception
+
+    and:
+      resetItems.each {
+        assert it.status == OutboxStatus.PENDING
+      }
+      failingItem.status == OutboxStatus.PENDING // It's status was updated before the exception was thrown.
+      notResetItems.each {
+        assert it.status == OutboxStatus.RUNNING
+      }
+  }
+}

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxMonitorSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxMonitorSpec.groovy
@@ -5,7 +5,7 @@ import io.github.bluegroundltd.outbox.OutboxItemProcessorDecorator
 import io.github.bluegroundltd.outbox.OutboxLocksProvider
 import io.github.bluegroundltd.outbox.OutboxProcessingAction
 import io.github.bluegroundltd.outbox.OutboxProcessingHost
-import io.github.bluegroundltd.outbox.OutboxProcessingHostBuilder
+import io.github.bluegroundltd.outbox.OutboxProcessingHostComposer
 import io.github.bluegroundltd.outbox.TransactionalOutbox
 import io.github.bluegroundltd.outbox.TransactionalOutboxImpl
 import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher
@@ -34,7 +34,7 @@ class OutboxMonitorSpec extends Specification {
   private ExecutorService executor = Mock()
   private List<OutboxItemProcessorDecorator> decorators = (1..5).collect { Mock(OutboxItemProcessorDecorator) }
   private Duration threadPoolTimeOut = Duration.ofMillis(5000)
-  private OutboxProcessingHostBuilder processingHostBuilder = Mock()
+  private OutboxProcessingHostComposer processingHostComposer = Mock()
 
   private TransactionalOutbox transactionalOutbox
 
@@ -51,7 +51,7 @@ class OutboxMonitorSpec extends Specification {
       executor,
       decorators,
       threadPoolTimeOut,
-      processingHostBuilder
+      processingHostComposer
     )
   }
 
@@ -64,7 +64,7 @@ class OutboxMonitorSpec extends Specification {
       transactionalOutbox.processInstantOutbox(instantOutbox)
 
     then:
-      1 * processingHostBuilder.build(_, _) >> {
+      1 * processingHostComposer.compose(_, _) >> {
         OutboxProcessingAction action, List<OutboxItemProcessorDecorator> decorators ->
           assert action instanceof OutboxGroupProcessor
           assert decorators == this.decorators
@@ -98,7 +98,7 @@ class OutboxMonitorSpec extends Specification {
       transactionalOutbox.processInstantOutbox(instantOutbox)
 
     then:
-      1 * processingHostBuilder.build(_, _) >> {
+      1 * processingHostComposer.compose(_, _) >> {
         OutboxProcessingAction action, List<OutboxItemProcessorDecorator> decorators ->
           assert action instanceof OutboxGroupProcessor
           assert decorators == this.decorators
@@ -142,7 +142,7 @@ class OutboxMonitorSpec extends Specification {
         return item
       }
       items.eachWithIndex { item, index ->
-        1 * processingHostBuilder.build(_, _) >> { OutboxProcessingAction action, List<OutboxItemProcessorDecorator> decorators ->
+        1 * processingHostComposer.compose(_, _) >> { OutboxProcessingAction action, List<OutboxItemProcessorDecorator> decorators ->
           assert action instanceof OutboxGroupProcessor
           assert decorators == this.decorators
           return processingHosts[index]
@@ -185,7 +185,7 @@ class OutboxMonitorSpec extends Specification {
         }
         return item
       }
-      1 * processingHostBuilder.build(_, _) >> { OutboxProcessingAction action, List<OutboxItemProcessorDecorator> decorators ->
+      1 * processingHostComposer.compose(_, _) >> { OutboxProcessingAction action, List<OutboxItemProcessorDecorator> decorators ->
         assert action instanceof OutboxGroupProcessor
         assert decorators == this.decorators
         return processingHost

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxMonitorSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxMonitorSpec.groovy
@@ -1,6 +1,6 @@
 package io.github.bluegroundltd.outbox.unit
 
-import io.github.bluegroundltd.outbox.OutboxItemProcessor
+import io.github.bluegroundltd.outbox.OutboxGroupProcessor
 import io.github.bluegroundltd.outbox.OutboxItemProcessorDecorator
 import io.github.bluegroundltd.outbox.OutboxLocksProvider
 import io.github.bluegroundltd.outbox.OutboxProcessingAction
@@ -66,7 +66,7 @@ class OutboxMonitorSpec extends Specification {
     then:
       1 * processingHostBuilder.build(_, _) >> {
         OutboxProcessingAction action, List<OutboxItemProcessorDecorator> decorators ->
-          assert action instanceof OutboxItemProcessor
+          assert action instanceof OutboxGroupProcessor
           assert decorators == this.decorators
           return processingHost
       }
@@ -100,7 +100,7 @@ class OutboxMonitorSpec extends Specification {
     then:
       1 * processingHostBuilder.build(_, _) >> {
         OutboxProcessingAction action, List<OutboxItemProcessorDecorator> decorators ->
-          assert action instanceof OutboxItemProcessor
+          assert action instanceof OutboxGroupProcessor
           assert decorators == this.decorators
           return processingHost
       }
@@ -143,7 +143,7 @@ class OutboxMonitorSpec extends Specification {
       }
       items.eachWithIndex { item, index ->
         1 * processingHostBuilder.build(_, _) >> { OutboxProcessingAction action, List<OutboxItemProcessorDecorator> decorators ->
-          assert action instanceof OutboxItemProcessor
+          assert action instanceof OutboxGroupProcessor
           assert decorators == this.decorators
           return processingHosts[index]
         }
@@ -186,7 +186,7 @@ class OutboxMonitorSpec extends Specification {
         return item
       }
       1 * processingHostBuilder.build(_, _) >> { OutboxProcessingAction action, List<OutboxItemProcessorDecorator> decorators ->
-        assert action instanceof OutboxItemProcessor
+        assert action instanceof OutboxGroupProcessor
         assert decorators == this.decorators
         return processingHost
       }

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxProcessingHostBuilderSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxProcessingHostBuilderSpec.groovy
@@ -1,0 +1,26 @@
+package io.github.bluegroundltd.outbox.unit
+
+import io.github.bluegroundltd.outbox.OutboxProcessingAction
+import io.github.bluegroundltd.outbox.OutboxProcessingHostBuilder
+import spock.lang.Specification
+
+class OutboxProcessingHostBuilderSpec extends Specification {
+  private OutboxProcessingHostBuilder builder = new OutboxProcessingHostBuilder()
+
+  def "Should build an [OutboxProcessingHost] when [build] is invoked"() {
+    given:
+      def processingAction = Mock(OutboxProcessingAction)
+      // We use an empty decorator list to simplify the test.
+      // There is a stand-alone test for the decorator logic in [OutboxProcessingHostSpec].
+      def decorators = []
+
+    when:
+      def result = builder.build(processingAction, decorators)
+
+    then:
+      0 * _
+
+    and:
+      result != null
+  }
+}

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxProcessingHostComposerSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxProcessingHostComposerSpec.groovy
@@ -1,13 +1,13 @@
 package io.github.bluegroundltd.outbox.unit
 
 import io.github.bluegroundltd.outbox.OutboxProcessingAction
-import io.github.bluegroundltd.outbox.OutboxProcessingHostBuilder
+import io.github.bluegroundltd.outbox.OutboxProcessingHostComposer
 import spock.lang.Specification
 
-class OutboxProcessingHostBuilderSpec extends Specification {
-  private OutboxProcessingHostBuilder builder = new OutboxProcessingHostBuilder()
+class OutboxProcessingHostComposerSpec extends Specification {
+  private OutboxProcessingHostComposer composer = new OutboxProcessingHostComposer()
 
-  def "Should build an [OutboxProcessingHost] when [build] is invoked"() {
+  def "Should build an [OutboxProcessingHost] when [compose] is invoked"() {
     given:
       def processingAction = Mock(OutboxProcessingAction)
       // We use an empty decorator list to simplify the test.
@@ -15,7 +15,7 @@ class OutboxProcessingHostBuilderSpec extends Specification {
       def decorators = []
 
     when:
-      def result = builder.build(processingAction, decorators)
+      def result = composer.compose(processingAction, decorators)
 
     then:
       0 * _

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxProcessingHostSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxProcessingHostSpec.groovy
@@ -1,16 +1,16 @@
 package io.github.bluegroundltd.outbox.unit
 
-import io.github.bluegroundltd.outbox.OutboxItemProcessor
 import io.github.bluegroundltd.outbox.OutboxItemProcessorDecorator
+import io.github.bluegroundltd.outbox.OutboxProcessingAction
 import io.github.bluegroundltd.outbox.OutboxProcessingHost
 import spock.lang.Specification
 
 class OutboxProcessingHostSpec extends Specification {
-  private OutboxItemProcessor processor = Mock()
+  private OutboxProcessingAction processingAction = Mock()
 
   // By default use a no-decorators host to simplify the tests.
   // There is a stand-alone test for the decorator logic.
-  private OutboxProcessingHost processingHost = new OutboxProcessingHost(processor, [])
+  private OutboxProcessingHost processingHost = new OutboxProcessingHost(processingAction, [])
 
   def "Should decorate the processor with the decorators when being instantiated"() {
     given:
@@ -21,7 +21,7 @@ class OutboxProcessingHostSpec extends Specification {
       def runnables = decorators.collect { Mock(Runnable) }
 
     when:
-      def processingHostWithDecorator = new OutboxProcessingHost(processor, decorators)
+      def processingHostWithDecorator = new OutboxProcessingHost(processingAction, decorators)
 
     then:
       1 * decorators[0].decorate(_) >> {
@@ -41,7 +41,7 @@ class OutboxProcessingHostSpec extends Specification {
       processingHost.run()
 
     then:
-      1 * processor.run()
+      1 * processingAction.run()
       0 * _
 
     and:
@@ -53,8 +53,8 @@ class OutboxProcessingHostSpec extends Specification {
       processingHost.run()
 
     then:
-      1 * processor.run() >> { throw new Exception("Processing Exception") }
-      1 * processor.reset()
+      1 * processingAction.run() >> { throw new Exception("Processing Exception") }
+      1 * processingAction.reset()
       0 * _
 
     and:
@@ -66,7 +66,7 @@ class OutboxProcessingHostSpec extends Specification {
       processingHost.reset()
 
     then:
-      1 * processor.reset()
+      1 * processingAction.reset()
       0 * _
 
     and:

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxShutdownSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxShutdownSpec.groovy
@@ -3,6 +3,7 @@ package io.github.bluegroundltd.outbox.unit
 import io.github.bluegroundltd.outbox.OutboxHandler
 import io.github.bluegroundltd.outbox.OutboxLocksProvider
 import io.github.bluegroundltd.outbox.OutboxProcessingHost
+import io.github.bluegroundltd.outbox.OutboxProcessingHostBuilder
 import io.github.bluegroundltd.outbox.TransactionalOutbox
 import io.github.bluegroundltd.outbox.TransactionalOutboxImpl
 import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher
@@ -30,6 +31,7 @@ class OutboxShutdownSpec extends Specification {
   private OutboxItemFactory outboxItemFactory = Mock()
   private ExecutorService executor = Mock()
   private Duration threadPoolTimeOut = Duration.ofMillis(5000)
+  private OutboxProcessingHostBuilder processingHostBuilder = Mock()
 
   private TransactionalOutbox transactionalOutbox
 
@@ -45,7 +47,8 @@ class OutboxShutdownSpec extends Specification {
       DURATION_ONE_HOUR,
       executor,
       [],
-      threadPoolTimeOut
+      threadPoolTimeOut,
+      processingHostBuilder
     )
   }
 

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxShutdownSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxShutdownSpec.groovy
@@ -3,7 +3,7 @@ package io.github.bluegroundltd.outbox.unit
 import io.github.bluegroundltd.outbox.OutboxHandler
 import io.github.bluegroundltd.outbox.OutboxLocksProvider
 import io.github.bluegroundltd.outbox.OutboxProcessingHost
-import io.github.bluegroundltd.outbox.OutboxProcessingHostBuilder
+import io.github.bluegroundltd.outbox.OutboxProcessingHostComposer
 import io.github.bluegroundltd.outbox.TransactionalOutbox
 import io.github.bluegroundltd.outbox.TransactionalOutboxImpl
 import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher
@@ -31,7 +31,7 @@ class OutboxShutdownSpec extends Specification {
   private OutboxItemFactory outboxItemFactory = Mock()
   private ExecutorService executor = Mock()
   private Duration threadPoolTimeOut = Duration.ofMillis(5000)
-  private OutboxProcessingHostBuilder processingHostBuilder = Mock()
+  private OutboxProcessingHostComposer processingHostComposer = Mock()
 
   private TransactionalOutbox transactionalOutbox
 
@@ -48,7 +48,7 @@ class OutboxShutdownSpec extends Specification {
       executor,
       [],
       threadPoolTimeOut,
-      processingHostBuilder
+      processingHostComposer
     )
   }
 

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/TransactionalOutboxBuilderSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/TransactionalOutboxBuilderSpec.groovy
@@ -28,7 +28,7 @@ class TransactionalOutboxBuilderSpec extends UnitTestSpecification {
       def builder = TransactionalOutboxBuilder.make(clock)
 
     and:
-      def handlerA = new DummyOutboxHandler()
+      def handlerA = new DummyOutboxHandler(clock)
       def handlerB = GroovyMock(OutboxHandler)
       def mockedBType = GroovyMock(OutboxType)
       def handlers = Set.of(handlerA, handlerB)
@@ -77,8 +77,8 @@ class TransactionalOutboxBuilderSpec extends UnitTestSpecification {
       def builder = TransactionalOutboxBuilder.make(clock)
 
     and:
-      def handlerA = new DummyOutboxHandler()
-      def handlerB = new DummyOutboxHandler()
+      def handlerA = new DummyOutboxHandler(clock)
+      def handlerB = new DummyOutboxHandler(clock)
       def handlers = Set.of(handlerA, handlerB)
 
     when:

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/DummyOutboxHandler.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/DummyOutboxHandler.groovy
@@ -4,11 +4,18 @@ import io.github.bluegroundltd.outbox.OutboxHandler
 import io.github.bluegroundltd.outbox.item.OutboxPayload
 import io.github.bluegroundltd.outbox.item.OutboxType
 
+import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 
 class DummyOutboxHandler implements OutboxHandler {
   private static OutboxType type = new DummyOutboxType()
+
+  private Clock clock
+
+  DummyOutboxHandler(Clock clock = null) {
+    this.clock = clock ?: Clock.systemUTC()
+  }
 
   @Override
   OutboxType getSupportedType() {
@@ -17,12 +24,12 @@ class DummyOutboxHandler implements OutboxHandler {
 
   @Override
   String serialize(OutboxPayload payload) {
-    return null
+    return "dummyPayload"
   }
 
   @Override
   Instant getNextExecutionTime(long currentRetries) {
-    return null
+    return Instant.now(clock) + Duration.ofHours(1)
   }
 
   @Override
@@ -37,25 +44,17 @@ class DummyOutboxHandler implements OutboxHandler {
   void handleFailure(String payload) {}
 
   @Override
-
-  @Override
   Duration getRetentionDuration() {
-    return null
+    return Duration.ofHours(1)
   }
 }
 
-class DummyHandler extends DummyOutboxHandler {
+class DelayingOutboxHandler extends DummyOutboxHandler {
 
-  @Override
-  String serialize(OutboxPayload payload) {
-    return "dummyPayload"
+  DelayingOutboxHandler(Clock clock = null) {
+    super(clock)
   }
 
   @Override
-  Instant getNextExecutionTime(long currentRetries) {
-    return Instant.now()
-  }
-
-  @Override
-  void handle(String payload) { sleep(50000); }
+  void handle(String payload) { sleep(50000) }
 }

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/DummyOutboxHandler.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/DummyOutboxHandler.groovy
@@ -1,51 +1,14 @@
 package io.github.bluegroundltd.outbox.utils
 
-import io.github.bluegroundltd.outbox.OutboxHandler
-import io.github.bluegroundltd.outbox.item.OutboxPayload
 import io.github.bluegroundltd.outbox.item.OutboxType
 
 import java.time.Clock
-import java.time.Duration
-import java.time.Instant
 
-class DummyOutboxHandler implements OutboxHandler {
-  private static OutboxType type = new DummyOutboxType()
-
-  private Clock clock
+class DummyOutboxHandler extends MockOutboxHandler {
+  private final static OutboxType TYPE = new DummyOutboxType()
 
   DummyOutboxHandler(Clock clock = null) {
-    this.clock = clock ?: Clock.systemUTC()
-  }
-
-  @Override
-  OutboxType getSupportedType() {
-    return type
-  }
-
-  @Override
-  String serialize(OutboxPayload payload) {
-    return "dummyPayload"
-  }
-
-  @Override
-  Instant getNextExecutionTime(long currentRetries) {
-    return Instant.now(clock) + Duration.ofHours(1)
-  }
-
-  @Override
-  boolean hasReachedMaxRetries(long retries) {
-    return false
-  }
-
-  @Override
-  void handle(String payload) {}
-
-  @Override
-  void handleFailure(String payload) {}
-
-  @Override
-  Duration getRetentionDuration() {
-    return Duration.ofHours(1)
+    super(TYPE, clock)
   }
 }
 

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/DummyOutboxHandler.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/DummyOutboxHandler.groovy
@@ -12,12 +12,3 @@ class DummyOutboxHandler extends MockOutboxHandler {
   }
 }
 
-class DelayingOutboxHandler extends DummyOutboxHandler {
-
-  DelayingOutboxHandler(Clock clock = null) {
-    super(clock)
-  }
-
-  @Override
-  void handle(String payload) { sleep(50000) }
-}

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/DummyOutboxType.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/DummyOutboxType.groovy
@@ -1,0 +1,10 @@
+package io.github.bluegroundltd.outbox.utils
+
+import groovy.transform.EqualsAndHashCode
+
+@EqualsAndHashCode(includeFields=true)
+class DummyOutboxType extends SimpleOutboxType {
+  DummyOutboxType() {
+    super("dummyOutboxType")
+  }
+}

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/FailingOutboxHandler.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/FailingOutboxHandler.groovy
@@ -1,0 +1,35 @@
+package io.github.bluegroundltd.outbox.utils
+
+import io.github.bluegroundltd.outbox.item.OutboxType
+import org.jetbrains.annotations.NotNull
+
+import java.time.Clock
+
+class FailingOutboxHandler extends MockOutboxHandler {
+  final static String DEFAULT_FAILURE_REASON = "Failed to handle item"
+
+  private final boolean maxRetriesReached
+  private final String failureReason
+
+  FailingOutboxHandler(
+    @NotNull OutboxType type,
+    Clock clock = null,
+    boolean maxRetriesReached = false,
+    String failureReason = null
+  ) {
+    super(type, clock)
+    this.maxRetriesReached = maxRetriesReached
+    this.failureReason = failureReason ?: DEFAULT_FAILURE_REASON
+  }
+
+  @Override
+  void handle(String payload) {
+    throw new RuntimeException(failureReason)
+  }
+
+  @Override
+  boolean hasReachedMaxRetries(long retries) {
+    return maxRetriesReached
+  }
+}
+

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/InMemoryOutboxStore.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/InMemoryOutboxStore.groovy
@@ -1,0 +1,48 @@
+package io.github.bluegroundltd.outbox.utils
+
+import io.github.bluegroundltd.outbox.item.OutboxItem
+import io.github.bluegroundltd.outbox.item.OutboxStatus
+import io.github.bluegroundltd.outbox.store.OutboxFilter
+import io.github.bluegroundltd.outbox.store.OutboxStore
+import org.jetbrains.annotations.NotNull
+
+import java.time.Instant
+
+class InMemoryOutboxStore implements OutboxStore {
+  private final Map<Long, OutboxItem> outboxItems = new HashMap<>()
+
+  @Override
+  OutboxItem insert(@NotNull OutboxItem outboxItem) {
+    outboxItems[outboxItem.id] = outboxItem
+    return outboxItem
+  }
+
+  @Override
+  OutboxItem update(@NotNull OutboxItem outboxItem) {
+    if (!outboxItems.containsKey(outboxItem.id)) {
+      throw new IllegalArgumentException("Item with id ${outboxItem.id} not found")
+    }
+    outboxItems[outboxItem.id] = outboxItem
+    return outboxItem
+  }
+
+  @Override
+  List<OutboxItem> fetch(@NotNull OutboxFilter outboxFilter) {
+    return outboxItems.values().toList()
+  }
+
+  @Override
+  void deleteCompletedItems(@NotNull Instant now) {
+    outboxItems.removeAll { id, item ->
+      item.status == OutboxStatus.COMPLETED && item.deleteAfter.isBefore(now)
+    }
+  }
+
+  OutboxItem get(@NotNull Long id) {
+    return outboxItems[id]
+  }
+
+  List<OutboxItem> get(@NotNull List<Long> ids) {
+    return ids.unique().collect { get(it) }.findAll { it != null }
+  }
+}

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/MockOutboxHandler.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/MockOutboxHandler.groovy
@@ -1,0 +1,54 @@
+package io.github.bluegroundltd.outbox.utils
+
+import io.github.bluegroundltd.outbox.OutboxHandler
+import io.github.bluegroundltd.outbox.item.OutboxPayload
+import io.github.bluegroundltd.outbox.item.OutboxType
+import org.jetbrains.annotations.NotNull
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+
+class MockOutboxHandler implements OutboxHandler {
+  private final OutboxType type
+  private final Clock clock
+
+  MockOutboxHandler(
+    @NotNull OutboxType type,
+    Clock clock = null
+  ) {
+    this.type = type
+    this.clock = clock ?: Clock.systemUTC()
+  }
+
+  @Override
+  OutboxType getSupportedType() {
+    return type
+  }
+
+  @Override
+  String serialize(OutboxPayload payload) {
+    return "dummyPayload"
+  }
+
+  @Override
+  Instant getNextExecutionTime(long currentRetries) {
+    return Instant.now(clock) + Duration.ofHours(1)
+  }
+
+  @Override
+  boolean hasReachedMaxRetries(long retries) {
+    return false
+  }
+
+  @Override
+  void handle(String payload) {}
+
+  @Override
+  void handleFailure(String payload) {}
+
+  @Override
+  Duration getRetentionDuration() {
+    return Duration.ofHours(1)
+  }
+}

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/OutboxItemBuilder.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/OutboxItemBuilder.groovy
@@ -1,6 +1,5 @@
 package io.github.bluegroundltd.outbox.utils
 
-import groovy.transform.EqualsAndHashCode
 import io.github.bluegroundltd.outbox.item.OutboxItem
 import io.github.bluegroundltd.outbox.item.OutboxStatus
 import io.github.bluegroundltd.outbox.item.OutboxType
@@ -87,13 +86,5 @@ class OutboxItemBuilder implements SpecHelper {
       rerunAfter,
       deleteAfter
     )
-  }
-}
-
-@EqualsAndHashCode(includeFields=true)
-class DummyOutboxType implements OutboxType {
-  @Override
-  String getType() {
-    return "dummyOutboxType"
   }
 }

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/OutboxItemBuilder.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/OutboxItemBuilder.groovy
@@ -1,5 +1,6 @@
 package io.github.bluegroundltd.outbox.utils
 
+import groovy.transform.EqualsAndHashCode
 import io.github.bluegroundltd.outbox.item.OutboxItem
 import io.github.bluegroundltd.outbox.item.OutboxStatus
 import io.github.bluegroundltd.outbox.item.OutboxType
@@ -89,6 +90,7 @@ class OutboxItemBuilder implements SpecHelper {
   }
 }
 
+@EqualsAndHashCode(includeFields=true)
 class DummyOutboxType implements OutboxType {
   @Override
   String getType() {

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/SimpleOutboxType.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/SimpleOutboxType.groovy
@@ -1,0 +1,18 @@
+package io.github.bluegroundltd.outbox.utils
+
+import groovy.transform.EqualsAndHashCode
+import io.github.bluegroundltd.outbox.item.OutboxType
+
+@EqualsAndHashCode(includeFields=true)
+class SimpleOutboxType implements OutboxType {
+  private final String type
+
+  SimpleOutboxType(String type) {
+    this.type = type
+  }
+
+  @Override
+  String getType() {
+    return type
+  }
+}


### PR DESCRIPTION
## Description
Introduces `OutboxItemGroup` which will be used to represent a collection of outbox items that will be processed in order. Accordingly, it also introduces:
- A class (`OutboxGroupProcessor`) that is responsible for processing said groups.
- An abstraction (`OutboxProcessingAction`) to represent and encapsulate the act of processing outbox item(s).
- A series of refactorings and enhancements to support the notion of the `OutboxItemGroup` being the unit of processing (e.g. resetting the status of items that were not processed).
- A series of enhancements on the test suites.

### Reference
[JIRA: Refactor `OutboxItemProcessor` to work with groups](https://devblueground.atlassian.net/browse/SW-587)