### PR TITLE
[SW-587] Improve mechanism for 'stopping' the processing of outbox items

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Transactional Outbox is published on `mavenCentral`. In order to use it just add
 
 ```gradle
 
-implementation("io.github.bluegroundltd:transactional-outbox-core:2.0.0")
+implementation("io.github.bluegroundltd:transactional-outbox-core:2.0.1")
 
 ```
 

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=io.github.bluegroundltd
 POM_ARTIFACT_ID=transactional-outbox-core
-VERSION_NAME=2.0.0
+VERSION_NAME=2.0.1
 
 POM_NAME=Transactional Outbox Core
 POM_DESCRIPTION=Easily implement the transactional outbox pattern in your JVM application

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxItemProcessor.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxItemProcessor.kt
@@ -21,14 +21,7 @@ internal class OutboxItemProcessor(
     private val logger: Logger = LoggerFactory.getLogger(OutboxItemProcessor::class.java)
   }
 
-  private var isStopped = false
-
   override fun run() {
-    if (isStopped) {
-      logger.info("$LOGGER_PREFIX Skipping execution of outbox item with id: ${item.id} because processor is stopped.")
-      return
-    }
-
     if (!handler.supports(item.type)) {
       logger.error("$LOGGER_PREFIX Handler ${handler::class.java} does not support item of type: ${item.type}")
       return
@@ -73,8 +66,6 @@ internal class OutboxItemProcessor(
    * against the rarity of the occurrence and the limited nature of its effect.
    */
   fun reset() {
-    logger.debug("$LOGGER_PREFIX Stopping outbox item processor")
-    isStopped = true
     if (item.status == OutboxStatus.RUNNING) {
       logger.info("$LOGGER_PREFIX Resetting outbox item with id: ${item.id} to PENDING")
       item.status = OutboxStatus.PENDING

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxItemProcessor.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxItemProcessor.kt
@@ -16,13 +16,19 @@ internal class OutboxItemProcessor(
   private val store: OutboxStore,
   private val clock: Clock,
 ) : Runnable {
-
   companion object {
     private const val LOGGER_PREFIX = "[OUTBOX-ITEM-PROCESSOR]"
     private val logger: Logger = LoggerFactory.getLogger(OutboxItemProcessor::class.java)
   }
 
+  private var isStopped = false
+
   override fun run() {
+    if (isStopped) {
+      logger.info("$LOGGER_PREFIX Skipping execution of outbox item with id: ${item.id} because processor is stopped.")
+      return
+    }
+
     if (!handler.supports(item.type)) {
       logger.error("$LOGGER_PREFIX Handler ${handler::class.java} does not support item of type: ${item.type}")
       return
@@ -42,6 +48,37 @@ internal class OutboxItemProcessor(
         handleRetryableFailure(exception)
       }
     } finally {
+      store.update(item)
+    }
+  }
+
+  /**
+   * Performs required cleanup on the processor and resets the outbox item state so that it will be retried
+   * on the next run.
+   *
+   * This method along with [run] present a concurrency risk since they are both modifying the state of
+   * the outbox item. Therefore, it is the responsibility of the caller to ensure that it is called in
+   * a thread-safe manner.
+   *
+   * Still, it should be noted that the result of a potential concurrency issue, i.e. updating the item
+   * twice and overwriting its values is not critical. The worst case scenario is that an item that has
+   * been completed (or failed) may revert to pending state and be retried. While this is not ideal,
+   * this has always been the case and due to the nature of the problem, cannot be completely avoided.
+   * For example, there is always a chance that the processor is terminated immediately after the item
+   * has been processed but before its state has been updated. Obviously, this is not related to a
+   * concurrency issue, but still will result in the same outcome.
+   *
+   * We could add a synchronization mechanism (e.g. `synchronized`) to limit the issue in extreme cases
+   * that are unrelated to concurrency, but we should consider the cost of introducing such a mechanism
+   * against the rarity of the occurrence and the limited nature of its effect.
+   */
+  fun reset() {
+    logger.debug("$LOGGER_PREFIX Stopping outbox item processor")
+    isStopped = true
+    if (item.status == OutboxStatus.RUNNING) {
+      logger.info("$LOGGER_PREFIX Resetting outbox item with id: ${item.id} to PENDING")
+      item.status = OutboxStatus.PENDING
+      item.rerunAfter = null
       store.update(item)
     }
   }

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
@@ -20,21 +20,23 @@ import java.time.ZoneId
 class TransactionalOutboxImplSpec extends Specification {
   private static final Duration DURATION_ONE_HOUR = Duration.ofHours(1)
   private static final Duration DURATION_ONE_NANO = Duration.ofNanos(1)
-  Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())
-  OutboxHandler handler = new DummyHandler()
-  OutboxType type = handler.getSupportedType()
-  Map<OutboxType, OutboxHandler> handlers = Map.of(type, handler)
+  private static final Clock CLOCK = Clock.fixed(Instant.now(), ZoneId.systemDefault())
 
-  OutboxLocksProvider monitorLocksProvider = Mock()
-  OutboxLocksProvider cleanupLocksProvider = Mock()
-  OutboxStore store = Mock()
-  InstantOutboxPublisher instantOutboxPublisher = Mock()
-  OutboxItemFactory outboxItemFactory = Mock()
-  TransactionalOutbox transactionalOutbox
+  private OutboxHandler handler = new DummyHandler()
+  private OutboxType type = handler.getSupportedType()
+  private Map<OutboxType, OutboxHandler> handlers = Map.of(type, handler)
+
+  private OutboxLocksProvider monitorLocksProvider = Mock()
+  private OutboxLocksProvider cleanupLocksProvider = Mock()
+  private OutboxStore store = Mock()
+  private InstantOutboxPublisher instantOutboxPublisher = Mock()
+  private OutboxItemFactory outboxItemFactory = Mock()
+
+  private TransactionalOutbox transactionalOutbox
 
   def setup() {
     transactionalOutbox = new TransactionalOutboxImpl(
-      clock,
+      CLOCK,
       handlers,
       monitorLocksProvider,
       cleanupLocksProvider,
@@ -50,7 +52,7 @@ class TransactionalOutboxImplSpec extends Specification {
 
   def "Should delegate to outbox store when `cleanup` is invoked"() {
     given:
-      def now = Instant.now(clock)
+      def now = Instant.now(CLOCK)
 
     when:
       transactionalOutbox.cleanup()

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
@@ -6,14 +6,10 @@ import io.github.bluegroundltd.outbox.TransactionalOutbox
 import io.github.bluegroundltd.outbox.TransactionalOutboxImpl
 import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher
 import io.github.bluegroundltd.outbox.executor.FixedThreadPoolExecutorServiceFactory
-import io.github.bluegroundltd.outbox.item.OutboxItem
-import io.github.bluegroundltd.outbox.item.OutboxStatus
 import io.github.bluegroundltd.outbox.item.OutboxType
 import io.github.bluegroundltd.outbox.item.factory.OutboxItemFactory
-import io.github.bluegroundltd.outbox.store.OutboxFilter
 import io.github.bluegroundltd.outbox.store.OutboxStore
 import io.github.bluegroundltd.outbox.utils.DummyHandler
-import io.github.bluegroundltd.outbox.utils.OutboxItemBuilder
 import spock.lang.Specification
 
 import java.time.Clock
@@ -50,95 +46,6 @@ class TransactionalOutboxImplSpec extends Specification {
       [],
       DURATION_ONE_NANO
     )
-  }
-
-  def "Should return when shutdown is called and the executor is empty"() {
-    when:
-      transactionalOutbox.shutdown()
-
-    then:
-      0 * _
-  }
-
-  def "Should force outbox shutdown when shutdown is called and the timeout elapsed before termination"() {
-    given:
-      def expectedOutboxItem =
-        OutboxItemBuilder.make().withType(type).build()
-
-    and:
-      def now = Instant.now(clock)
-
-    when:
-      transactionalOutbox.monitor()
-
-    then:
-      1 * monitorLocksProvider.acquire()
-      1 * store.fetch(_) >> { OutboxFilter filter ->
-        with(filter) {
-          outboxPendingFilter.nextRunLessThan == now
-          outboxRunningFilter.rerunAfterLessThan == now
-        }
-        [expectedOutboxItem]
-      }
-      1 * store.update(_) >> { OutboxItem item ->
-        with(item) {
-          it.status == OutboxStatus.RUNNING
-          it.lastExecution == now
-          it.rerunAfter == item.lastExecution + DURATION_ONE_HOUR
-        }
-        return item
-      }
-      1 * monitorLocksProvider.release()
-      0 * _
-
-    when:
-      transactionalOutbox.shutdown()
-
-    then:
-      0 * _
-  }
-
-  def "Should delegate to the outbox store when shutdown is called and there are tasks that didn't start execution"() {
-    given:
-      def pendingItem = OutboxItemBuilder.make().withType(type).build()
-      def items = [pendingItem, pendingItem]
-      def now = Instant.now(clock)
-
-    when:
-      transactionalOutbox.monitor()
-
-    then:
-      1 * monitorLocksProvider.acquire()
-      1 * store.fetch(_) >> { OutboxFilter filter ->
-        with(filter) {
-          outboxPendingFilter.nextRunLessThan == now
-        }
-        items
-      }
-      items.size() * store.update(_) >> { OutboxItem item ->
-        with(item) {
-          it.status == OutboxStatus.RUNNING
-          it.lastExecution == now
-          it.rerunAfter == item.lastExecution + DURATION_ONE_HOUR
-        }
-        return item
-      }
-      1 * monitorLocksProvider.release()
-      0 * _
-
-    when:
-      transactionalOutbox.shutdown()
-
-    then:
-      1 * store.update(_) >> { OutboxItem item ->
-        with(item) {
-          it.status == OutboxStatus.PENDING
-          it.nextRun == now
-          it.rerunAfter == null
-        }
-        return item
-      }
-      0 * _
   }
 
   def "Should delegate to outbox store when `cleanup` is invoked"() {

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxItemProcessorSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxItemProcessorSpec.groovy
@@ -100,22 +100,16 @@ class OutboxItemProcessorSpec extends Specification {
       0 * _
   }
 
-  def "Should stop processing and set item status to 'PENDING' when [reset] is invoked"() {
+  def "Should set item status to 'PENDING' when [reset] is invoked"() {
     when:
       processor.reset()
 
     then:
       1 * store.update(resetItem)
       0 * _
-
-    when:
-      processor.run()
-
-    then:
-      0 * _
   }
 
-  def "Should stop processing and do nothing else when [reset] is invoked and item status is #itemStatus"() {
+  def "Should do nothing when [reset] is invoked and item status is #itemStatus"() {
     given:
       def itemProcessor = new OutboxItemProcessor(
         itemBuilder.withStatus(itemStatus).build(),

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxShutdownSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxShutdownSpec.groovy
@@ -6,7 +6,6 @@ import io.github.bluegroundltd.outbox.OutboxLocksProvider
 import io.github.bluegroundltd.outbox.TransactionalOutbox
 import io.github.bluegroundltd.outbox.TransactionalOutboxImpl
 import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher
-import io.github.bluegroundltd.outbox.item.OutboxItem
 import io.github.bluegroundltd.outbox.item.OutboxStatus
 import io.github.bluegroundltd.outbox.item.OutboxType
 import io.github.bluegroundltd.outbox.item.factory.OutboxItemFactory
@@ -23,20 +22,22 @@ import java.util.concurrent.TimeUnit
 
 class OutboxShutdownSpec extends Specification {
   private static final Duration DURATION_ONE_HOUR = Duration.ofHours(1)
-  Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())
-  Map<OutboxType, OutboxHandler> handlers = Mock()
-  OutboxLocksProvider monitorLocksProvider = Mock()
-  OutboxLocksProvider cleanupLocksProvider = Mock()
-  OutboxStore store = Mock()
-  InstantOutboxPublisher instantOutboxPublisher = Mock()
-  OutboxItemFactory outboxItemFactory = Mock()
-  ExecutorService executor = Mock()
-  Duration threadPoolTimeOut = Duration.ofMillis(5000)
-  TransactionalOutbox transactionalOutbox
+  private static final Clock CLOCK = Clock.fixed(Instant.now(), ZoneId.systemDefault())
+
+  private Map<OutboxType, OutboxHandler> handlers = [:]
+  private OutboxLocksProvider monitorLocksProvider = Mock()
+  private OutboxLocksProvider cleanupLocksProvider = Mock()
+  private OutboxStore store = Mock()
+  private InstantOutboxPublisher instantOutboxPublisher = Mock()
+  private OutboxItemFactory outboxItemFactory = Mock()
+  private ExecutorService executor = Mock()
+  private Duration threadPoolTimeOut = Duration.ofMillis(5000)
+
+  private TransactionalOutbox transactionalOutbox
 
   def setup() {
     transactionalOutbox = new TransactionalOutboxImpl(
-      clock,
+      CLOCK,
       handlers,
       monitorLocksProvider,
       cleanupLocksProvider,
@@ -52,11 +53,13 @@ class OutboxShutdownSpec extends Specification {
 
   def "Should delegate to the outbox store when shutdown is called and the timeout elapsed before termination"() {
     given:
-      def runningItem = OutboxItemBuilder.makeRunning()
+      // Can't mock OutboxItemProcessor (because it's final) so we need an actual implementation.
+      def itemBuilder = OutboxItemBuilder.make()
+      def runningItem = itemBuilder.withStatus(OutboxStatus.RUNNING).withRerunAfter().build()
+      def resetItem = itemBuilder.withStatus(OutboxStatus.PENDING).withoutRerunAfter().build()
       def handler = GroovyMock(OutboxHandler)
-      def processor = new OutboxItemProcessor(runningItem, handler, store, clock)
+      def processor = new OutboxItemProcessor(runningItem, handler, store, CLOCK)
       def expected = [processor]
-      def now = Instant.now(clock)
 
     when:
       transactionalOutbox.shutdown()
@@ -65,13 +68,7 @@ class OutboxShutdownSpec extends Specification {
       1 * executor.shutdown()
       1 * executor.awaitTermination(threadPoolTimeOut.toSeconds(), TimeUnit.SECONDS) >> false
       1 * executor.shutdownNow() >> expected
-      1 * store.update(_) >> { OutboxItem item ->
-        with(item) {
-          item.status == OutboxStatus.PENDING
-          item.nextRun == now
-          item.rerunAfter == null
-        }
-      }
+      1 * store.update(resetItem)
       0 * _
       noExceptionThrown()
   }

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/OutboxItemBuilder.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/OutboxItemBuilder.groovy
@@ -53,6 +53,15 @@ class OutboxItemBuilder implements SpecHelper {
     this
   }
 
+  OutboxItemBuilder withRerunAfter(Instant rerunAfter) {
+    this.rerunAfter = rerunAfter
+    this
+  }
+
+  OutboxItemBuilder withoutRerunAfter() {
+    withRerunAfter(null)
+  }
+
   static OutboxItem makePending() {
     make().build()
   }

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/OutboxItemBuilder.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/OutboxItemBuilder.groovy
@@ -58,6 +58,10 @@ class OutboxItemBuilder implements SpecHelper {
     this
   }
 
+  OutboxItemBuilder withRerunAfter() {
+    withRerunAfter(generateInstant())
+  }
+
   OutboxItemBuilder withoutRerunAfter() {
     withRerunAfter(null)
   }


### PR DESCRIPTION
## Description
Encapsulates the process of 'resetting' an `OutboxItemProcessor` and its contained item(s). This allows for better control of the process and avoids leaking implementation details to external components (e.g. through the `getItem` method).

Due to concurrency issues (`run` and `reset` will usually run in different threads) this DOES NOT provide a bullet-proof reset mechanism but rather a good-enough method for handling most cases. However, past running experience has shown that these cases are already rare and their effect is rather limited.