### PR TITLE
[SW-587] Reset items on shutdown and simplify design of processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Transactional Outbox is published on `mavenCentral`. In order to use it just add
 
 ```gradle
 
-implementation("io.github.bluegroundltd:transactional-outbox-core:2.0.1")
+implementation("io.github.bluegroundltd:transactional-outbox-core:2.0.2")
 
 ```
 

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=io.github.bluegroundltd
 POM_ARTIFACT_ID=transactional-outbox-core
-VERSION_NAME=2.0.1
+VERSION_NAME=2.0.2
 
 POM_NAME=Transactional Outbox Core
 POM_DESCRIPTION=Easily implement the transactional outbox pattern in your JVM application

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/InvalidOutboxHandlerException.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/InvalidOutboxHandlerException.kt
@@ -1,0 +1,15 @@
+package io.github.bluegroundltd.outbox
+
+import io.github.bluegroundltd.outbox.item.OutboxItem
+
+internal data class InvalidOutboxHandlerException @JvmOverloads constructor(
+  private val item: OutboxItem,
+  override val message: String = formatDefaultMessage(item),
+  override val cause: Throwable? = null
+) : RuntimeException(message, cause) {
+  companion object {
+    private fun formatDefaultMessage(item: OutboxItem): String {
+      return "Invalid Outbox Handler for item with id: ${item.id} and type: ${item.type}"
+    }
+  }
+}

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxItemProcessor.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxItemProcessor.kt
@@ -17,13 +17,13 @@ internal class OutboxItemProcessor(
   private val handler: OutboxHandler,
   private val store: OutboxStore,
   private val clock: Clock,
-) : Runnable {
+) {
   companion object {
     private const val LOGGER_PREFIX = "[OUTBOX-ITEM-PROCESSOR]"
     private val logger: Logger = LoggerFactory.getLogger(OutboxItemProcessor::class.java)
   }
 
-  override fun run() {
+  fun run() {
     if (!handler.supports(item.type)) {
       logger.error("$LOGGER_PREFIX Handler ${handler::class.java} does not support item of type: ${item.type}")
       return

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxItemProcessor.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxItemProcessor.kt
@@ -26,7 +26,7 @@ internal class OutboxItemProcessor(
   fun run() {
     if (!handler.supports(item.type)) {
       logger.error("$LOGGER_PREFIX Handler ${handler::class.java} does not support item of type: ${item.type}")
-      return
+      throw InvalidOutboxHandlerException(item)
     }
 
     try {
@@ -42,6 +42,7 @@ internal class OutboxItemProcessor(
       } else {
         handleRetryableFailure(exception)
       }
+      throw exception
     } finally {
       store.update(item)
     }

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxItemProcessor.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxItemProcessor.kt
@@ -1,5 +1,6 @@
 package io.github.bluegroundltd.outbox
 
+import io.github.bluegroundltd.outbox.annotation.TestableOpenClass
 import io.github.bluegroundltd.outbox.item.OutboxItem
 import io.github.bluegroundltd.outbox.item.OutboxStatus
 import io.github.bluegroundltd.outbox.item.OutboxType
@@ -10,6 +11,7 @@ import java.time.Clock
 import java.time.Instant
 
 @Suppress("TooGenericExceptionCaught")
+@TestableOpenClass
 internal class OutboxItemProcessor(
   private val item: OutboxItem,
   private val handler: OutboxHandler,

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxProcessingHost.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/OutboxProcessingHost.kt
@@ -1,0 +1,35 @@
+package io.github.bluegroundltd.outbox
+
+import io.github.bluegroundltd.outbox.annotation.TestableOpenClass
+
+/**
+ * Serves as a host inside which outbox items will be processed.
+ *
+ * @param processor the processor that will be used to process the outbox items
+ * @param decorators a list of decorators that will be used to decorate the processor
+ *
+ * This component allows for separating the responsibilities of processing the items and being scheduled
+ * on an executor (i.e. implementing `Runnable`).
+ *
+ * From a design perspective it would have been preferable to be supplied with a pre-decorated processor.
+ * However, this is not currently possible due to the way the decoration process is defined (i.e. on top
+ * of [Runnable]). Once this has been changed to work on [OutboxItemProcessor] (see relevant discussion:
+ * https://github.com/bluegroundltd/transactional-outbox/discussions/24), it will no longer be the case
+ * and this component will be updated accordingly.
+ */
+@TestableOpenClass
+internal class OutboxProcessingHost(
+  private val processor: OutboxItemProcessor,
+  decorators: List<OutboxItemProcessorDecorator>
+) : Runnable {
+  private val runnable: Runnable = decorators
+    .fold(processor as Runnable) { decorated, decorator -> decorator.decorate(decorated) }
+
+  override fun run() {
+    runnable.run()
+  }
+
+  fun reset() {
+    processor.reset()
+  }
+}

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/InvalidOutboxHandlerExceptionSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/InvalidOutboxHandlerExceptionSpec.groovy
@@ -1,0 +1,39 @@
+package io.github.bluegroundltd.outbox.unit
+
+import io.github.bluegroundltd.outbox.InvalidOutboxHandlerException
+import io.github.bluegroundltd.outbox.item.OutboxItem
+import io.github.bluegroundltd.outbox.utils.OutboxItemBuilder
+import spock.lang.Specification
+
+class InvalidOutboxHandlerExceptionSpec extends Specification {
+  def "Should build an [InvalidOutboxHandlerException] with default values"() {
+    given:
+      def outboxItem = OutboxItemBuilder.make().build()
+      def expectedMessage = outboxItem.with {
+        "Invalid Outbox Handler for item with id: ${it.id} and type: ${it.type}"
+      }
+
+    when:
+      def exception = new InvalidOutboxHandlerException(outboxItem)
+
+    then:
+      exception.message == expectedMessage
+      exception.cause == null
+      0 * _
+  }
+
+  def "Should build an [InvalidOutboxHandlerException] with the supplied values"() {
+    given:
+      def outboxItem = GroovyMock(OutboxItem)
+      def message = "Exception Message"
+      def cause = Mock(Throwable)
+
+    when:
+      def exception = new InvalidOutboxHandlerException(outboxItem, message, cause)
+
+    then:
+      exception.message == message
+      exception.cause == cause
+      0 * _
+  }
+}

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxItemProcessorSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxItemProcessorSpec.groovy
@@ -1,5 +1,6 @@
 package io.github.bluegroundltd.outbox.unit
 
+import io.github.bluegroundltd.outbox.InvalidOutboxHandlerException
 import io.github.bluegroundltd.outbox.OutboxHandler
 import io.github.bluegroundltd.outbox.OutboxItemProcessor
 import io.github.bluegroundltd.outbox.item.OutboxItem
@@ -35,13 +36,20 @@ class OutboxItemProcessorSpec extends Specification {
     )
   }
 
-  def "Should do nothing when an erroneous item type is provided"() {
+  def "Should throw [InvalidOutboxHandlerException] when an erroneous item type is provided"() {
+    given:
+      def expectedException = new InvalidOutboxHandlerException(processedItem)
+
     when:
       processor.run()
 
     then:
       1 * handler.getSupportedType() >> Mock(OutboxType)
       0 * _
+
+    and:
+      def ex = thrown(InvalidOutboxHandlerException)
+      ex == expectedException
   }
 
   def "Should handle an item and update its status to 'COMPLETED' when [run] is called"() {
@@ -65,13 +73,16 @@ class OutboxItemProcessorSpec extends Specification {
       0 * _
   }
 
-  def "Should gracefully handle a processing failure when it has reached the max number of retries"() {
+  def "Should handle a processing failure when it has reached the max number of retries"() {
+    given:
+      def exception = new RuntimeException()
+
     when:
       processor.run()
 
     then:
       1 * handler.getSupportedType() >> processedItem.type
-      1 * handler.handle(processedItem.payload) >> { throw new Exception() }
+      1 * handler.handle(processedItem.payload) >> { throw exception }
       1 * handler.hasReachedMaxRetries(processedItem.retries) >> true
       1 * handler.handleFailure(processedItem.payload)
       1 * store.update(_) >> { OutboxItem item ->
@@ -81,18 +92,23 @@ class OutboxItemProcessorSpec extends Specification {
         }
       }
       0 * _
+
+    and:
+      def ex = thrown(Exception)
+      ex == exception
   }
 
   def "Should gracefully handle a processing failure when it hasn't reached the max number of retries"() {
     given:
       def expectedNextRun = Instant.now(clock)
+      def exception = new RuntimeException()
 
     when:
       processor.run()
 
     then:
       1 * handler.getSupportedType() >> processedItem.type
-      1 * handler.handle(processedItem.payload) >> { throw new Exception() }
+      1 * handler.handle(processedItem.payload) >> { throw exception }
       1 * handler.hasReachedMaxRetries(processedItem.retries) >> false
       1 * handler.getNextExecutionTime(processedItem.retries) >> expectedNextRun
       1 * store.update(_) >> { OutboxItem item ->
@@ -104,6 +120,10 @@ class OutboxItemProcessorSpec extends Specification {
         }
       }
       0 * _
+
+    and:
+      def ex = thrown(Exception)
+      ex == exception
   }
 
   def "Should set item status to 'PENDING' when [reset] is invoked"() {

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxItemProcessorSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxItemProcessorSpec.groovy
@@ -17,11 +17,10 @@ import java.time.ZoneId
 class OutboxItemProcessorSpec extends Specification {
   private Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())
 
-  private itemBuilder = OutboxItemBuilder.make()
-  private runningItem = itemBuilder.withStatus(OutboxStatus.RUNNING).build()
-  private resetItem = itemBuilder.withStatus(OutboxStatus.PENDING).withoutRerunAfter().build()
+  private itemBuilder = OutboxItemBuilder.make().withStatus(OutboxStatus.RUNNING).withRerunAfter()
+  private processedItem = itemBuilder.build()
+  private originalItem = itemBuilder.build() // Create an identical second to use it for comparisons.
 
-  private unsupportedOutboxType = GroovyMock(OutboxType)
   private OutboxHandler handler = GroovyMock()
   private OutboxStore store = GroovyMock()
 
@@ -29,7 +28,7 @@ class OutboxItemProcessorSpec extends Specification {
 
   def setup() {
     processor = new OutboxItemProcessor(
-      runningItem,
+      processedItem,
       handler,
       store,
       clock
@@ -41,11 +40,11 @@ class OutboxItemProcessorSpec extends Specification {
       processor.run()
 
     then:
-      1 * handler.getSupportedType() >> unsupportedOutboxType
+      1 * handler.getSupportedType() >> Mock(OutboxType)
       0 * _
   }
 
-  def "Should handle an item and update its status to completion when run is called"() {
+  def "Should handle an item and update its status to 'COMPLETED' when [run] is called"() {
     given:
       def retentionDuration = Duration.ofDays(10)
 
@@ -53,32 +52,38 @@ class OutboxItemProcessorSpec extends Specification {
       processor.run()
 
     then:
-      1 * handler.getSupportedType() >> runningItem.type
-      1 * handler.handle(runningItem.payload)
+      1 * handler.getSupportedType() >> processedItem.type
+      1 * handler.handle(processedItem.payload)
       1 * handler.getRetentionDuration() >> retentionDuration
       1 * store.update(_) >> { OutboxItem item ->
-        assert item.status == OutboxStatus.COMPLETED
-        assert item.deleteAfter == Instant.now(clock) + retentionDuration
+        assert item == originalItem.with {
+          status = OutboxStatus.COMPLETED
+          deleteAfter = Instant.now(clock) + retentionDuration
+          it
+        }
       }
       0 * _
   }
 
-  def "Should gracefully handle a failure during handling with max retries"() {
+  def "Should gracefully handle a processing failure when it has reached the max number of retries"() {
     when:
       processor.run()
 
     then:
-      1 * handler.getSupportedType() >> runningItem.type
-      1 * handler.handle(runningItem.payload) >> { throw new Exception() }
-      1 * handler.hasReachedMaxRetries(_) >> true
-      1 * handler.handleFailure(runningItem.payload)
+      1 * handler.getSupportedType() >> processedItem.type
+      1 * handler.handle(processedItem.payload) >> { throw new Exception() }
+      1 * handler.hasReachedMaxRetries(processedItem.retries) >> true
+      1 * handler.handleFailure(processedItem.payload)
       1 * store.update(_) >> { OutboxItem item ->
-        assert item.status == OutboxStatus.FAILED
+        assert item == originalItem.with {
+          status = OutboxStatus.FAILED
+          it
+        }
       }
       0 * _
   }
 
-  def "Should gracefully handle a failure during handling with no max retries"() {
+  def "Should gracefully handle a processing failure when it hasn't reached the max number of retries"() {
     given:
       def expectedNextRun = Instant.now(clock)
 
@@ -86,15 +91,16 @@ class OutboxItemProcessorSpec extends Specification {
       processor.run()
 
     then:
-      1 * handler.getSupportedType() >> runningItem.type
-      1 * handler.handle(runningItem.payload) >> { throw new Exception() }
-      1 * handler.hasReachedMaxRetries(_) >> false
-      1 * handler.getNextExecutionTime(_) >> expectedNextRun
+      1 * handler.getSupportedType() >> processedItem.type
+      1 * handler.handle(processedItem.payload) >> { throw new Exception() }
+      1 * handler.hasReachedMaxRetries(processedItem.retries) >> false
+      1 * handler.getNextExecutionTime(processedItem.retries) >> expectedNextRun
       1 * store.update(_) >> { OutboxItem item ->
-        with(item) {
-          status == OutboxStatus.PENDING
-          retries == 1
-          nextRun == expectedNextRun
+        assert item == originalItem.with {
+          status = OutboxStatus.PENDING
+          retries = originalItem.retries + 1
+          nextRun = expectedNextRun
+          it
         }
       }
       0 * _
@@ -105,7 +111,13 @@ class OutboxItemProcessorSpec extends Specification {
       processor.reset()
 
     then:
-      1 * store.update(resetItem)
+      1 * store.update(_) >> { OutboxItem item ->
+        assert item == originalItem.with {
+          status = OutboxStatus.PENDING
+          rerunAfter = null
+          it
+        }
+      }
       0 * _
   }
 

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxProcessingHostSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxProcessingHostSpec.groovy
@@ -1,0 +1,59 @@
+package io.github.bluegroundltd.outbox.unit
+
+import io.github.bluegroundltd.outbox.OutboxItemProcessor
+import io.github.bluegroundltd.outbox.OutboxItemProcessorDecorator
+import io.github.bluegroundltd.outbox.OutboxProcessingHost
+import spock.lang.Specification
+
+class OutboxProcessingHostSpec extends Specification {
+  private OutboxItemProcessor processor = Mock()
+
+  // By default use a no-decorators host to simplify the tests.
+  // There is a stand-alone test for the decorator logic.
+  private OutboxProcessingHost processingHost = new OutboxProcessingHost(processor, [])
+
+  def "Should decorate the processor with the decorators when being instantiated"() {
+    given:
+      def decorators = [
+        Mock(OutboxItemProcessorDecorator),
+        Mock(OutboxItemProcessorDecorator)
+      ]
+      def runnables = decorators.collect { Mock(Runnable) }
+
+    when:
+      def processingHostWithDecorator = new OutboxProcessingHost(processor, decorators)
+
+    then:
+      1 * decorators[0].decorate(processor) >> runnables[0]
+      1 * decorators[1].decorate(runnables[0]) >> runnables[1]
+      0 * _
+
+    and:
+      processingHostWithDecorator != null
+      noExceptionThrown()
+  }
+
+  def "Should delegate to the processor when [run] is called"() {
+    when:
+      processingHost.run()
+
+    then:
+      1 * processor.run()
+      0 * _
+
+    and:
+      noExceptionThrown()
+  }
+
+  def "Should delegate to the processor when [reset] is called"() {
+    when:
+      processingHost.reset()
+
+    then:
+      1 * processor.reset()
+      0 * _
+
+    and:
+      noExceptionThrown()
+  }
+}

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxShutdownSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxShutdownSpec.groovy
@@ -1,8 +1,8 @@
 package io.github.bluegroundltd.outbox.unit
 
 import io.github.bluegroundltd.outbox.OutboxHandler
-import io.github.bluegroundltd.outbox.OutboxItemProcessor
 import io.github.bluegroundltd.outbox.OutboxLocksProvider
+import io.github.bluegroundltd.outbox.OutboxProcessingHost
 import io.github.bluegroundltd.outbox.TransactionalOutbox
 import io.github.bluegroundltd.outbox.TransactionalOutboxImpl
 import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher
@@ -51,8 +51,8 @@ class OutboxShutdownSpec extends Specification {
 
   def "Should delegate to the outbox store when shutdown is called and the timeout elapsed before termination"() {
     given:
-      def processor = Mock(OutboxItemProcessor)
-      def expected = [processor]
+      def processingHost = Mock(OutboxProcessingHost)
+      def expected = [processingHost]
 
     when:
       transactionalOutbox.shutdown()
@@ -61,7 +61,7 @@ class OutboxShutdownSpec extends Specification {
       1 * executor.shutdown()
       1 * executor.awaitTermination(threadPoolTimeOut.toSeconds(), TimeUnit.SECONDS) >> false
       1 * executor.shutdownNow() >> expected
-      1 * processor.stop()
+      1 * processingHost.reset()
       0 * _
 
     and:

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/OutboxItemBuilder.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/OutboxItemBuilder.groovy
@@ -23,7 +23,7 @@ class OutboxItemBuilder implements SpecHelper {
       type = new DummyOutboxType()
       status = OutboxStatus.PENDING
       payload = "dummyPayload"
-      retries = 0
+      retries = generateInt(10)
       nextRun = generateInstant()
       lastExecution = null
       rerunAfter = null

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/SpecHelper.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/SpecHelper.groovy
@@ -24,4 +24,12 @@ trait SpecHelper {
   Boolean generateBoolean() {
     srng.nextBoolean()
   }
+
+  int generateInt(Integer bound = null) {
+    (bound != null) ? Math.abs(srng.nextInt(bound)) : Math.abs(srng.nextInt())
+  }
+
+  int generateIntNonZero(Integer bound = null) {
+    generateInt(bound) + 1
+  }
 }


### PR DESCRIPTION
## Description
Introduces a new component (`OutboxProcessingHost`) that takes on the responsibility for being the entity that is scheduled on an executor (i.e. implementing `Runnable`). This provides a two-fold benefit:
- The objects being submitted to the executor are always `OutboxProcessingHost`. That means that during shutdown we are now able to properly retrieve them and perform any required actions.
- `OutboxItemProcessor` no longer needs to implement `Runnable`. This means that there is no longer the requirement of not throwing any exceptions. In turn, this allows for a simplified implementation and better (and more structured) error handling.

### Reference
[Resetting status of items on shutdown](https://github.com/bluegroundltd/transactional-outbox/discussions/24)