### PR TITLE
[SW-588] Refactor handling of `FAILED` items to account for groups

### DIFF
--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutboxBuilder.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutboxBuilder.kt
@@ -4,6 +4,8 @@ import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher
 import io.github.bluegroundltd.outbox.executor.FixedThreadPoolExecutorServiceFactory
 import io.github.bluegroundltd.outbox.item.OutboxType
 import io.github.bluegroundltd.outbox.item.factory.OutboxItemFactory
+import io.github.bluegroundltd.outbox.processing.OutboxItemProcessorDecorator
+import io.github.bluegroundltd.outbox.processing.OutboxProcessingHostComposer
 import io.github.bluegroundltd.outbox.store.OutboxStore
 import java.time.Clock
 import java.time.Duration

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutboxImpl.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutboxImpl.kt
@@ -8,6 +8,11 @@ import io.github.bluegroundltd.outbox.item.OutboxPayload
 import io.github.bluegroundltd.outbox.item.OutboxStatus
 import io.github.bluegroundltd.outbox.item.OutboxType
 import io.github.bluegroundltd.outbox.item.factory.OutboxItemFactory
+import io.github.bluegroundltd.outbox.processing.OutboxGroupProcessor
+import io.github.bluegroundltd.outbox.processing.OutboxItemProcessorDecorator
+import io.github.bluegroundltd.outbox.processing.OutboxProcessingAction
+import io.github.bluegroundltd.outbox.processing.OutboxProcessingHost
+import io.github.bluegroundltd.outbox.processing.OutboxProcessingHostComposer
 import io.github.bluegroundltd.outbox.store.OutboxFilter
 import io.github.bluegroundltd.outbox.store.OutboxStore
 import org.slf4j.Logger

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutboxImpl.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutboxImpl.kt
@@ -47,7 +47,12 @@ internal class TransactionalOutboxImpl(
   companion object {
     private const val LOGGER_PREFIX = "[OUTBOX]"
     private val logger: Logger = LoggerFactory.getLogger(TransactionalOutboxImpl::class.java)
-    private val STATUSES_ELIGIBLE_FOR_PROCESSING = EnumSet.of(OutboxStatus.PENDING, OutboxStatus.RUNNING)
+    private val STATUSES_RETRIEVED_FOR_PROCESSING = EnumSet.of(
+      OutboxStatus.PENDING,
+      OutboxStatus.RUNNING,
+      OutboxStatus.FAILED // Required for in-order processing in groups (i.e. they might precede other items).
+    )
+    private val STATUSES_TO_UPDATE_FOR_PROCESSING = EnumSet.of(OutboxStatus.PENDING, OutboxStatus.RUNNING)
   }
 
   override fun add(type: OutboxType, payload: OutboxPayload, shouldPublishAfterInsertion: Boolean) {
@@ -103,12 +108,12 @@ internal class TransactionalOutboxImpl(
   private fun fetchEligibleItems(): List<OutboxItem> {
     val (eligibleItems, erroneouslyFetchedItems) = outboxStore
       .fetch(OutboxFilter(Instant.now(clock)))
-      .partition { it.status in STATUSES_ELIGIBLE_FOR_PROCESSING }
+      .partition { it.status in STATUSES_RETRIEVED_FOR_PROCESSING }
 
     erroneouslyFetchedItems.forEach {
       logger.warn(
         "$LOGGER_PREFIX Outbox item with id ${it.id} erroneously fetched, as its status is ${it.status}. " +
-          "Expected status to be one of $STATUSES_ELIGIBLE_FOR_PROCESSING"
+          "Expected status to be one of $STATUSES_RETRIEVED_FOR_PROCESSING"
       )
     }
 
@@ -117,14 +122,19 @@ internal class TransactionalOutboxImpl(
 
   private fun markForProcessing(items: List<OutboxItem>): List<OutboxItem> {
     val now = Instant.now(clock)
-    return items.map {
-      it.copy(
+    return items.map { markForProcessing(it, now) }
+  }
+
+  private fun markForProcessing(item: OutboxItem, now: Instant): OutboxItem =
+    if (item.status in STATUSES_TO_UPDATE_FOR_PROCESSING) {
+      item.copy(
         status = OutboxStatus.RUNNING,
         lastExecution = now,
         rerunAfter = now.plus(rerunAfterDuration)
       )
+    } else {
+      item.copy()
     }
-  }
 
   private fun processItem(item: OutboxItem) {
     val processor = makeOutboxProcessor(item)

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/InvalidOutboxHandlerException.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/InvalidOutboxHandlerException.kt
@@ -1,4 +1,4 @@
-package io.github.bluegroundltd.outbox
+package io.github.bluegroundltd.outbox.processing
 
 import io.github.bluegroundltd.outbox.item.OutboxItem
 

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/InvalidOutboxStatusException.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/InvalidOutboxStatusException.kt
@@ -1,0 +1,23 @@
+package io.github.bluegroundltd.outbox.processing
+
+import io.github.bluegroundltd.outbox.item.OutboxItem
+import io.github.bluegroundltd.outbox.item.OutboxStatus
+
+internal data class InvalidOutboxStatusException @JvmOverloads constructor(
+  private val item: OutboxItem,
+  private val expectedStatues: Set<OutboxStatus> = emptySet(),
+  override val message: String = formatDefaultMessage(item, expectedStatues),
+  override val cause: Throwable? = null
+) : RuntimeException(message, cause) {
+  companion object {
+    private fun formatDefaultMessage(item: OutboxItem, expectedStatues: Set<OutboxStatus>) =
+      "Invalid status: ${item.status} for outbox: ${item.id}.${formatExpectedStatusesFragment(expectedStatues)}"
+
+    private fun formatExpectedStatusesFragment(expectedStatues: Set<OutboxStatus>) =
+      if (expectedStatues.isNotEmpty()) {
+        " Expected one of: ${expectedStatues.joinToString()}."
+      } else {
+        ""
+      }
+  }
+}

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxGroupProcessor.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxGroupProcessor.kt
@@ -1,5 +1,6 @@
-package io.github.bluegroundltd.outbox
+package io.github.bluegroundltd.outbox.processing
 
+import io.github.bluegroundltd.outbox.OutboxHandler
 import io.github.bluegroundltd.outbox.annotation.TestableOpenClass
 import io.github.bluegroundltd.outbox.item.OutboxItem
 import io.github.bluegroundltd.outbox.item.OutboxItemGroup

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxItemProcessor.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxItemProcessor.kt
@@ -81,16 +81,15 @@ internal class OutboxItemProcessor(
   }
 
   private fun resolveHandler(item: OutboxItem): OutboxHandler {
-    val handler = handlerResolver(item)
-    if (handler == null) {
-      val message = "Handler could not be resolved for item with id: ${item.id} and type: ${item.type}"
-      logger.error("$LOGGER_PREFIX $message")
-      throw InvalidOutboxHandlerException(item, message)
-    }
+    val handler = handlerResolver(item) ?: throw InvalidOutboxHandlerException(
+      item,
+      "Handler could not be resolved for item with id: ${item.id} and type: ${item.type}"
+    )
     if (!handler.supports(item.type)) {
-      val message = "Handler ${handler::class.java} does not support item of type: ${item.type}"
-      logger.error("$LOGGER_PREFIX $message")
-      throw InvalidOutboxHandlerException(item, message)
+      throw InvalidOutboxHandlerException(
+        item,
+        "Handler ${handler::class.java} does not support item of type: ${item.type}"
+      )
     }
     return handler
   }

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxItemProcessor.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxItemProcessor.kt
@@ -25,6 +25,10 @@ internal class OutboxItemProcessor(
   }
 
   override fun run() {
+    if (item.status != OutboxStatus.RUNNING) {
+      throw InvalidOutboxStatusException(item, setOf(OutboxStatus.RUNNING))
+    }
+
     val handler = resolveHandler(item)
 
     try {

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxItemProcessor.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxItemProcessor.kt
@@ -1,5 +1,6 @@
-package io.github.bluegroundltd.outbox
+package io.github.bluegroundltd.outbox.processing
 
+import io.github.bluegroundltd.outbox.OutboxHandler
 import io.github.bluegroundltd.outbox.annotation.TestableOpenClass
 import io.github.bluegroundltd.outbox.item.OutboxItem
 import io.github.bluegroundltd.outbox.item.OutboxStatus

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxItemProcessorDecorator.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxItemProcessorDecorator.kt
@@ -1,9 +1,9 @@
-package io.github.bluegroundltd.outbox
+package io.github.bluegroundltd.outbox.processing
 
 /**
  * A callback interface for a decorator to be applied to the internal Outbox Item Processors.
  *
- * The primary use case is to set some execution context around the invocation of the [OutboxHandler] that is called
+ * The primary use case is to set some execution context around the invocation of the outbox processor that is called
  * by the asynchronously-invoked Outbox Item Processor, or to provide some monitoring/statistics for the handler's execution.
  *
  * Implementations must be **thread-safe**

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxProcessingAction.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxProcessingAction.kt
@@ -1,4 +1,4 @@
-package io.github.bluegroundltd.outbox
+package io.github.bluegroundltd.outbox.processing
 
 /**
  * A 'runnable' action that will be executed in order to process outbox item(s).

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxProcessingHost.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxProcessingHost.kt
@@ -1,6 +1,8 @@
 package io.github.bluegroundltd.outbox.processing
 
 import io.github.bluegroundltd.outbox.annotation.TestableOpenClass
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /**
  * Serves as a host inside which outbox items will be processed.
@@ -23,11 +25,16 @@ internal class OutboxProcessingHost(
   private val processingAction: OutboxProcessingAction,
   decorators: List<OutboxItemProcessorDecorator>
 ) : Runnable {
+  companion object {
+    private const val LOGGER_PREFIX = "[OUTBOX-PROCESSING-HOST]"
+    private val logger: Logger = LoggerFactory.getLogger(OutboxGroupProcessor::class.java)
+  }
 
   private val processorRunnable = Runnable {
     try {
       processingAction.run()
     } catch (e: Exception) {
+      logger.error("$LOGGER_PREFIX ${e.message}")
       processingAction.reset()
     }
   }

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxProcessingHost.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxProcessingHost.kt
@@ -1,4 +1,4 @@
-package io.github.bluegroundltd.outbox
+package io.github.bluegroundltd.outbox.processing
 
 import io.github.bluegroundltd.outbox.annotation.TestableOpenClass
 

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxProcessingHostComposer.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxProcessingHostComposer.kt
@@ -1,4 +1,4 @@
-package io.github.bluegroundltd.outbox
+package io.github.bluegroundltd.outbox.processing
 
 import io.github.bluegroundltd.outbox.annotation.TestableOpenClass
 

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/store/OutboxFilter.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/store/OutboxFilter.kt
@@ -15,6 +15,10 @@ class OutboxRunningFilter(
   val rerunAfterLessThan: Instant
 ) : AbstractOutboxFilter(OutboxStatus.RUNNING)
 
+class OutboxFailedFilter(
+  val deleteAfterLessThan: Instant
+) : AbstractOutboxFilter(OutboxStatus.COMPLETED)
+
 class OutboxFilter(
   nextRunLessThan: Instant,
   rerunAfterLessThan: Instant = nextRunLessThan

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
@@ -2,7 +2,7 @@ package io.github.bluegroundltd.outbox.integration
 
 import io.github.bluegroundltd.outbox.OutboxHandler
 import io.github.bluegroundltd.outbox.OutboxLocksProvider
-import io.github.bluegroundltd.outbox.OutboxProcessingHostComposer
+import io.github.bluegroundltd.outbox.processing.OutboxProcessingHostComposer
 import io.github.bluegroundltd.outbox.TransactionalOutbox
 import io.github.bluegroundltd.outbox.TransactionalOutboxImpl
 import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/processing/InvalidOutboxHandlerExceptionSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/processing/InvalidOutboxHandlerExceptionSpec.groovy
@@ -1,6 +1,5 @@
-package io.github.bluegroundltd.outbox.unit
+package io.github.bluegroundltd.outbox.processing
 
-import io.github.bluegroundltd.outbox.InvalidOutboxHandlerException
 import io.github.bluegroundltd.outbox.item.OutboxItem
 import io.github.bluegroundltd.outbox.utils.OutboxItemBuilder
 import spock.lang.Specification

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/processing/InvalidOutboxStatusExceptionSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/processing/InvalidOutboxStatusExceptionSpec.groovy
@@ -1,0 +1,59 @@
+package io.github.bluegroundltd.outbox.processing
+
+import io.github.bluegroundltd.outbox.item.OutboxItem
+import io.github.bluegroundltd.outbox.item.OutboxStatus
+import io.github.bluegroundltd.outbox.utils.OutboxItemBuilder
+import spock.lang.Specification
+
+class InvalidOutboxStatusExceptionSpec extends Specification {
+  def "Should build an [InvalidOutboxStatusException] with default values"() {
+    given:
+      def outboxItem = OutboxItemBuilder.make().build()
+      def expectedMessage = outboxItem.with {
+        "Invalid status: ${it.status} for outbox: ${it.id}."
+      }
+
+    when:
+      def exception = new InvalidOutboxStatusException(outboxItem)
+
+    then:
+      exception.message == expectedMessage
+      exception.cause == null
+      0 * _
+  }
+
+  def "Should build an [InvalidOutboxStatusException] with expected statuses"() {
+    given:
+      def outboxItem = OutboxItemBuilder.make().build()
+      def expectedStatues = (OutboxStatus.values() - outboxItem.status).toList().toSet()
+
+    and:
+      def expectedMessage = outboxItem.with {
+        "Invalid status: ${it.status} for outbox: ${it.id}. Expected one of: ${expectedStatues.join(", ")}."
+      }
+
+    when:
+      def exception = new InvalidOutboxStatusException(outboxItem, expectedStatues)
+
+    then:
+      exception.message == expectedMessage
+      exception.cause == null
+      0 * _
+  }
+
+  def "Should build an [InvalidOutboxStatusException] with the supplied values"() {
+    given:
+      def outboxItem = GroovyMock(OutboxItem)
+      def expectedStatues = OutboxStatus.values().toList().toSet()
+      def message = "Exception Message"
+      def cause = Mock(Throwable)
+
+    when:
+      def exception = new InvalidOutboxStatusException(outboxItem, expectedStatues, message, cause)
+
+    then:
+      exception.message == message
+      exception.cause == cause
+      0 * _
+  }
+}

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/processing/OutboxGroupProcessorSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/processing/OutboxGroupProcessorSpec.groovy
@@ -1,6 +1,5 @@
-package io.github.bluegroundltd.outbox.unit
+package io.github.bluegroundltd.outbox.processing
 
-import io.github.bluegroundltd.outbox.OutboxGroupProcessor
 import io.github.bluegroundltd.outbox.OutboxHandler
 import io.github.bluegroundltd.outbox.item.OutboxItem
 import io.github.bluegroundltd.outbox.item.OutboxItemGroup

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/processing/OutboxItemProcessorSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/processing/OutboxItemProcessorSpec.groovy
@@ -1,8 +1,6 @@
-package io.github.bluegroundltd.outbox.unit
+package io.github.bluegroundltd.outbox.processing
 
-import io.github.bluegroundltd.outbox.InvalidOutboxHandlerException
 import io.github.bluegroundltd.outbox.OutboxHandler
-import io.github.bluegroundltd.outbox.OutboxItemProcessor
 import io.github.bluegroundltd.outbox.item.OutboxItem
 import io.github.bluegroundltd.outbox.item.OutboxStatus
 import io.github.bluegroundltd.outbox.item.OutboxType

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/processing/OutboxItemProcessorSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/processing/OutboxItemProcessorSpec.groovy
@@ -35,6 +35,33 @@ class OutboxItemProcessorSpec extends Specification {
     )
   }
 
+  def "Should throw [InvalidOutboxStatusException] when a outbox status is #status"() {
+    given:
+      def outboxItem = itemBuilder.withStatus(status as OutboxStatus).build()
+      def itemProcessor = new OutboxItemProcessor(
+        outboxItem,
+        { null },
+        store,
+        clock
+      )
+
+    and:
+      def expectedException = new InvalidOutboxStatusException(outboxItem, [OutboxStatus.RUNNING].toSet())
+
+    when:
+      itemProcessor.run()
+
+    then:
+      0 * _
+
+    and:
+      def ex = thrown(InvalidOutboxStatusException)
+      ex == expectedException
+
+    where:
+      status << OutboxStatus.values() - OutboxStatus.RUNNING
+  }
+
   def "Should throw [InvalidOutboxHandlerException] when a handler cannot be resolved"() {
     given:
       def itemProcessor = new OutboxItemProcessor(

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/processing/OutboxProcessingHostComposerSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/processing/OutboxProcessingHostComposerSpec.groovy
@@ -1,7 +1,5 @@
-package io.github.bluegroundltd.outbox.unit
+package io.github.bluegroundltd.outbox.processing
 
-import io.github.bluegroundltd.outbox.OutboxProcessingAction
-import io.github.bluegroundltd.outbox.OutboxProcessingHostComposer
 import spock.lang.Specification
 
 class OutboxProcessingHostComposerSpec extends Specification {

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/processing/OutboxProcessingHostSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/processing/OutboxProcessingHostSpec.groovy
@@ -1,8 +1,5 @@
-package io.github.bluegroundltd.outbox.unit
+package io.github.bluegroundltd.outbox.processing
 
-import io.github.bluegroundltd.outbox.OutboxItemProcessorDecorator
-import io.github.bluegroundltd.outbox.OutboxProcessingAction
-import io.github.bluegroundltd.outbox.OutboxProcessingHost
 import spock.lang.Specification
 
 class OutboxProcessingHostSpec extends Specification {

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxAddSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxAddSpec.groovy
@@ -2,7 +2,7 @@ package io.github.bluegroundltd.outbox.unit
 
 import io.github.bluegroundltd.outbox.OutboxHandler
 import io.github.bluegroundltd.outbox.OutboxLocksProvider
-import io.github.bluegroundltd.outbox.OutboxProcessingHostComposer
+import io.github.bluegroundltd.outbox.processing.OutboxProcessingHostComposer
 import io.github.bluegroundltd.outbox.TransactionalOutbox
 import io.github.bluegroundltd.outbox.TransactionalOutboxImpl
 import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxCleanupSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxCleanupSpec.groovy
@@ -1,7 +1,7 @@
 package io.github.bluegroundltd.outbox.unit
 
 import io.github.bluegroundltd.outbox.OutboxLocksProvider
-import io.github.bluegroundltd.outbox.OutboxProcessingHostComposer
+import io.github.bluegroundltd.outbox.processing.OutboxProcessingHostComposer
 import io.github.bluegroundltd.outbox.TransactionalOutbox
 import io.github.bluegroundltd.outbox.TransactionalOutboxImpl
 import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxMonitorSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxMonitorSpec.groovy
@@ -115,11 +115,15 @@ class OutboxMonitorSpec extends Specification {
     given:
       def pendingItem = OutboxItemBuilder.makePending()
       def runningItem = OutboxItemBuilder.make().withStatus(OutboxStatus.RUNNING).build()
-      def items = [pendingItem, runningItem]
+      def failedItem = OutboxItemBuilder.make().withStatus(OutboxStatus.FAILED).build()
+      def completedItem = OutboxItemBuilder.make().withStatus(OutboxStatus.COMPLETED).build()
+      def fetchedItems = [pendingItem, runningItem, failedItem, completedItem]
+      def toBeProcessedItems = [pendingItem, runningItem, failedItem]
+      def markedForProcessing = [pendingItem, runningItem]
 
     and:
       def now = Instant.now(clock)
-      def processingHosts = items.collect { Mock(OutboxProcessingHost) }
+      def processingHosts = toBeProcessedItems.collect { Mock(OutboxProcessingHost) }
 
     when:
       transactionalOutbox.monitor()
@@ -131,9 +135,11 @@ class OutboxMonitorSpec extends Specification {
           outboxPendingFilter.nextRunLessThan == now
           outboxRunningFilter.rerunAfterLessThan == now
         }
-        items
+        fetchedItems
       }
-      items.size() * store.update(_) >> { OutboxItem item ->
+
+    and: "The pending and running items are marked for processing while the failed item is stored as-is"
+      markedForProcessing.size() * store.update(_) >> { OutboxItem item ->
         with(item) {
           it.status == OutboxStatus.RUNNING
           it.lastExecution == now
@@ -141,7 +147,18 @@ class OutboxMonitorSpec extends Specification {
         }
         return item
       }
-      items.eachWithIndex { item, index ->
+      1 * store.update(_) >> { OutboxItem item ->
+        with(item) {
+          it.id == failedItem.id
+          it.status == OutboxStatus.FAILED
+          it.lastExecution == failedItem.lastExecution
+          it.rerunAfter == failedItem.rerunAfter
+        }
+        return item
+      }
+
+    and: "A processor is created for each item and submitted for execution"
+      toBeProcessedItems.eachWithIndex { item, index ->
         1 * processingHostComposer.compose(_, _) >> { OutboxProcessingAction action, List<OutboxItemProcessorDecorator> decorators ->
           assert action instanceof OutboxGroupProcessor
           assert decorators == this.decorators
@@ -149,6 +166,8 @@ class OutboxMonitorSpec extends Specification {
         }
         1 * executor.execute(processingHosts[index])
       }
+
+    and:
       1 * monitorLocksProvider.release()
       0 * _
   }

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxMonitorSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxMonitorSpec.groovy
@@ -1,11 +1,11 @@
 package io.github.bluegroundltd.outbox.unit
 
-import io.github.bluegroundltd.outbox.OutboxGroupProcessor
-import io.github.bluegroundltd.outbox.OutboxItemProcessorDecorator
+import io.github.bluegroundltd.outbox.processing.OutboxGroupProcessor
+import io.github.bluegroundltd.outbox.processing.OutboxItemProcessorDecorator
 import io.github.bluegroundltd.outbox.OutboxLocksProvider
-import io.github.bluegroundltd.outbox.OutboxProcessingAction
-import io.github.bluegroundltd.outbox.OutboxProcessingHost
-import io.github.bluegroundltd.outbox.OutboxProcessingHostComposer
+import io.github.bluegroundltd.outbox.processing.OutboxProcessingAction
+import io.github.bluegroundltd.outbox.processing.OutboxProcessingHost
+import io.github.bluegroundltd.outbox.processing.OutboxProcessingHostComposer
 import io.github.bluegroundltd.outbox.TransactionalOutbox
 import io.github.bluegroundltd.outbox.TransactionalOutboxImpl
 import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxShutdownSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxShutdownSpec.groovy
@@ -2,8 +2,8 @@ package io.github.bluegroundltd.outbox.unit
 
 import io.github.bluegroundltd.outbox.OutboxHandler
 import io.github.bluegroundltd.outbox.OutboxLocksProvider
-import io.github.bluegroundltd.outbox.OutboxProcessingHost
-import io.github.bluegroundltd.outbox.OutboxProcessingHostComposer
+import io.github.bluegroundltd.outbox.processing.OutboxProcessingHost
+import io.github.bluegroundltd.outbox.processing.OutboxProcessingHostComposer
 import io.github.bluegroundltd.outbox.TransactionalOutbox
 import io.github.bluegroundltd.outbox.TransactionalOutboxImpl
 import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher


### PR DESCRIPTION
## Description
Updates the processing pipeline (`TransactionOutboxImpl` and `OutboxItemProcessor`) to be able to handle items with a `FAILED` status. This is to account for the fact that a `FAILED` item could potentially precede other items in the processing order and should therefore block their execution too.

### Reference
Resolves [[SW-588]](https://devblueground.atlassian.net/browse/SW-588).