### PR TITLE
feat: Allow specifying thread priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ class OutboxConfiguration(
     return TransactionalOutboxBuilder
       .make(clock)
       .withHandlers(outboxHandlers)
+      // Ideally you want your thread pool < db connection pool size or similar
+      .withThreadPoolSize(5) 
+      // Override the default Thread priority with caution
+      // If you are facing performance issues, you should
+      // adjust the thread pool size first.
+      // .withThreadPriority(Thread.NORM_PRIORITY)
       .withMonitorLocksProvider(monitorLocksProvider)
       .withCleanupLocksProvider(cleanupLocksProvider)
       .withStore(outboxStore)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Transactional Outbox is published on `mavenCentral`. In order to use it just add
 
 ```gradle
 
-implementation("io.github.bluegroundltd:transactional-outbox-core:2.0.4")
+implementation("io.github.bluegroundltd:transactional-outbox-core:2.1.0")
 
 ```
 

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=io.github.bluegroundltd
 POM_ARTIFACT_ID=transactional-outbox-core
-VERSION_NAME=2.0.4
+VERSION_NAME=2.1.0
 
 POM_NAME=Transactional Outbox Core
 POM_DESCRIPTION=Easily implement the transactional outbox pattern in your JVM application

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/executor/FixedThreadPoolExecutorServiceFactory.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/executor/FixedThreadPoolExecutorServiceFactory.kt
@@ -11,9 +11,11 @@ import java.util.concurrent.Executors
  */
 internal class FixedThreadPoolExecutorServiceFactory(
   threadPoolSize: Int? = null,
+  threadPriority: Int? = null,
   private val threadNameFormat: String = DEFAULT_THREAD_NAME_FORMAT
 ) {
   private val threadPoolSize = threadPoolSize ?: DEFAULT_THREAD_POOL_SIZE
+  private val threadPriority = threadPriority ?: Thread.NORM_PRIORITY
 
   companion object {
     private const val DEFAULT_THREAD_POOL_SIZE = 10
@@ -25,7 +27,7 @@ internal class FixedThreadPoolExecutorServiceFactory(
     logger.debug("Creating fixed thread pool with size: $threadPoolSize and name format \"$threadNameFormat\"")
     return Executors.newFixedThreadPool(
       threadPoolSize,
-      ThreadFactoryBuilder().setNameFormat(threadNameFormat).build()
+      ThreadFactoryBuilder().setNameFormat(threadNameFormat).setPriority(threadPriority).build()
     )
   }
 }

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
@@ -60,7 +60,7 @@ class TransactionalOutboxImplSpec extends Specification {
     instantOutboxPublisher,
     outboxItemFactory,
     DURATION_ONE_HOUR,
-    new FixedThreadPoolExecutorServiceFactory(1, "").make(),
+    new FixedThreadPoolExecutorServiceFactory(1, null, "").make(),
     [],
     DURATION_ONE_NANO,
     processingHostComposer

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/executor/FixedThreadPoolExecutorServiceFactorySpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/executor/FixedThreadPoolExecutorServiceFactorySpec.groovy
@@ -27,9 +27,10 @@ class FixedThreadPoolExecutorServiceFactorySpec extends UnitTestSpecification {
   def "Should create a FixedThreadPool ExecutorService with custom configuration"() {
     given:
       def expectedThreadPoolSize = 5
+      def expectedThreadPriority = Thread.MIN_PRIORITY
 
     when:
-      def factory = new FixedThreadPoolExecutorServiceFactory(5, "")
+      def factory = new FixedThreadPoolExecutorServiceFactory(5, Thread.MIN_PRIORITY, "")
 
     then:
       def executorService = factory.make()
@@ -43,5 +44,6 @@ class FixedThreadPoolExecutorServiceFactorySpec extends UnitTestSpecification {
     and:
       threadPoolExecutorService.getCorePoolSize() == expectedThreadPoolSize
       threadPoolExecutorService.getMaximumPoolSize() == expectedThreadPoolSize
+      threadPoolExecutorService.getThreadFactory().newThread({}).getPriority() == expectedThreadPriority
   }
 }


### PR DESCRIPTION
Although not widely recommended as a practice due to differences between platforms since Java
uses native Threads, I believe it is worth testing out its impact on web applications where we clearly
want web requests (served by acceptor threads and request processing threads) not to be "blocked"
 by background jobs.
