### PR TITLE
[SW-581] Refactor `processInstantOutbox` to use monitor with hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Transactional Outbox is published on `mavenCentral`. In order to use it just add
 
 ```gradle
 
-implementation("io.github.bluegroundltd:transactional-outbox-core:2.1.1")
+implementation("io.github.bluegroundltd:transactional-outbox-core:2.2.0")
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,26 @@ implementation("io.github.bluegroundltd:transactional-outbox-core:x.y.z")
 ```gradle
 implementation(files("../../../transactional-outbox/core/build/libs/core-x.y.z.jar"))
 ```
+
+* Alternative 3: You can publish a snapshot version of the library and make it available to maven snapshot repository.
+  1) Update the version in `gradle.properties` to a snapshot version, e.g. `2.2.0-SNAPSHOT`
+  2) Publish it using the instructions here: [Publish via your workstation](###Publish via your workstation) 
+  3) Snapshot will be published to the maven snapshot repository and you can use it in your project by adding the following to your `build.gradle` file:
+  ```gradle
+    repositories {
+      maven {
+        url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+        credentials {
+          username = <your_username> or <your_gpr_user>
+          password = <your_password> or <your_gpr_token>
+        }
+      }
+    }
+    dependencies {
+        implementation("io.github.bluegroundltd:transactional-outbox-core:2.2.0-SNAPSHOT")
+    }
+  ```
+
 ## Publishing
 
 Firstly, bump version in `gradle.properties` of `core` module, commit and push a PR. Once it gets merged, follow one of the two options below.

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -107,7 +107,12 @@ tasks.dokkaHtml.configure {
 signing {
   // This is required to allow using the signing key via the CI in ASCII armored format.
   // https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys
-  val signingKey: String? by project
-  val signingPassword: String? by project
-  useInMemoryPgpKeys(signingKey, signingPassword)
+  if (!project.gradle.startParameter.taskNames.any {
+    it.contains("publishToMavenLocal") ||
+    it.contains("publishMavenPublicationToMavenLocal")
+  }) {
+    val signingKey: String? by project
+    val signingPassword: String? by project
+    useInMemoryPgpKeys(signingKey, signingPassword)
+  }
 }

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=io.github.bluegroundltd
 POM_ARTIFACT_ID=transactional-outbox-core
-VERSION_NAME=2.1.1
+VERSION_NAME=2.2.0
 
 POM_NAME=Transactional Outbox Core
 POM_DESCRIPTION=Easily implement the transactional outbox pattern in your JVM application

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutbox.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutbox.kt
@@ -53,12 +53,21 @@ sealed interface TransactionalOutbox {
    * Handles a specific instant outbox
    * @param outbox
    */
+  @Deprecated(
+    message = "Deprecated in favor of using monitor with a hint (outbox item id)",
+    replaceWith = ReplaceWith("monitor(outbox.id)")
+  )
   fun processInstantOutbox(outbox: OutboxItem)
 
   /**
    * Monitors the outbox for new items and processes them
+   *
+   * @param id processes only the outbox item with this id instead of an eligible batch of items.
+   *
    */
-  fun monitor()
+  fun monitor(id: Long? = null)
+
+  fun monitor() = monitor(null)
 
   /**
    * Blocks new tasks and waits up to a specified period of time for all tasks to be completed.

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutboxImpl.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutboxImpl.kt
@@ -39,7 +39,8 @@ internal class TransactionalOutboxImpl(
   private val executor: ExecutorService,
   private val decorators: List<OutboxItemProcessorDecorator> = emptyList(),
   private val threadPoolTimeOut: Duration,
-  private val processingHostComposer: OutboxProcessingHostComposer
+  private val processingHostComposer: OutboxProcessingHostComposer,
+  private val instantOrderingEnabled: Boolean
 ) : TransactionalOutbox {
 
   private var inShutdownMode = AtomicBoolean(false)

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/item/factory/OutboxItemFactory.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/item/factory/OutboxItemFactory.kt
@@ -23,7 +23,8 @@ internal class OutboxItemFactory(
       type = type,
       status = OutboxStatus.PENDING,
       payload = handler.serialize(payload),
-      nextRun = handler.getNextExecutionTime(0),
+      // ensures that instant outbox items are picked up by monitor's fetching
+      nextRun = handler.getNextExecutionTime(0).minusMillis(1)
     )
   }
 

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/store/OutboxFilter.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/store/OutboxFilter.kt
@@ -17,7 +17,8 @@ class OutboxRunningFilter(
 
 class OutboxFilter(
   nextRunLessThan: Instant,
-  rerunAfterLessThan: Instant = nextRunLessThan
+  rerunAfterLessThan: Instant = nextRunLessThan,
+  val id: Long? = null // if set, it should fetch the item with this id instead of batch of items
 ) {
   val outboxPendingFilter: OutboxPendingFilter = OutboxPendingFilter(nextRunLessThan)
   val outboxRunningFilter: OutboxRunningFilter = OutboxRunningFilter(rerunAfterLessThan)

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/integration/TransactionalOutboxImplSpec.groovy
@@ -63,7 +63,8 @@ class TransactionalOutboxImplSpec extends Specification {
     new FixedThreadPoolExecutorServiceFactory(1, null, "").make(),
     [],
     DURATION_ONE_NANO,
-    processingHostComposer
+    processingHostComposer,
+    false
   )
 
   def "Should process all eligible items when [monitor] is invoked and set their statuses to 'COMPLETED'"() {

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/item/factory/OutboxItemFactorySpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/item/factory/OutboxItemFactorySpec.groovy
@@ -54,7 +54,7 @@ class OutboxItemFactorySpec extends Specification {
     and:
       def handler = GroovyMock(OutboxHandler)
       def serializedPayload = "serializedPayload"
-      def nextRun = GroovyMock(Instant)
+      def nextRun = Instant.now()
 
     when:
       OutboxItem result = outboxItemFactory.makeScheduledOutboxItem(type, payload)
@@ -70,7 +70,7 @@ class OutboxItemFactorySpec extends Specification {
       result.status == OutboxStatus.PENDING
       result.payload == serializedPayload
       result.retries == 0
-      result.nextRun == nextRun
+      result.nextRun == nextRun.minusMillis(1)
       !result.lastExecution
       !result.rerunAfter
   }

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxAddSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxAddSpec.groovy
@@ -34,20 +34,7 @@ class OutboxAddSpec extends UnitTestSpecification {
   TransactionalOutbox transactionalOutbox
 
   def setup() {
-    transactionalOutbox = new TransactionalOutboxImpl(
-      clock,
-      handlers,
-      monitorLocksProvider,
-      cleanupLocksProvider,
-      store,
-      instantOutboxPublisher,
-      outboxItemFactory,
-      DURATION_ONE_HOUR,
-      executor,
-      [],
-      threadPoolTimeOut,
-      processingHostComposer
-    )
+    transactionalOutbox = makeTransactionalOutbox(false)
   }
 
   def "Should delegate to outbox store when add is called"() {
@@ -88,5 +75,23 @@ class OutboxAddSpec extends UnitTestSpecification {
         assert it.outbox == savedOutbox
       })
       0 * _
+  }
+
+  private TransactionalOutboxImpl makeTransactionalOutbox(Boolean instantProcessingEnabled) {
+    new TransactionalOutboxImpl(
+      clock,
+      handlers,
+      monitorLocksProvider,
+      cleanupLocksProvider,
+      store,
+      instantOutboxPublisher,
+      outboxItemFactory,
+      DURATION_ONE_HOUR,
+      executor,
+      [],
+      threadPoolTimeOut,
+      processingHostComposer,
+      instantProcessingEnabled
+    )
   }
 }

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxCleanupSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxCleanupSpec.groovy
@@ -37,7 +37,8 @@ class OutboxCleanupSpec extends Specification {
     Mock(ExecutorService),
     [],
     Duration.ofMillis(5000),
-    Mock(OutboxProcessingHostComposer)
+    Mock(OutboxProcessingHostComposer),
+    false
   )
 
   def "Should acquire the clean up lock, delete all completed items and release it"() {

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxMonitorSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxMonitorSpec.groovy
@@ -39,20 +39,7 @@ class OutboxMonitorSpec extends Specification {
   private TransactionalOutbox transactionalOutbox
 
   def setup() {
-    transactionalOutbox = new TransactionalOutboxImpl(
-      clock,
-      [:],
-      monitorLocksProvider,
-      Mock(OutboxLocksProvider),
-      store,
-      Mock(InstantOutboxPublisher),
-      Mock(OutboxItemFactory),
-      DURATION_ONE_HOUR,
-      executor,
-      decorators,
-      threadPoolTimeOut,
-      processingHostComposer
-    )
+    transactionalOutbox = makeTransactionalOutbox(false)
   }
 
   def "Should delegate to the executor thread pool when an instant outbox is processed"() {
@@ -251,5 +238,23 @@ class OutboxMonitorSpec extends Specification {
       1 * monitorLocksProvider.release() >> { throw new RuntimeException() }
       0 * _
       noExceptionThrown()
+  }
+
+  private TransactionalOutboxImpl makeTransactionalOutbox(Boolean instantProcessingEnabled) {
+    new TransactionalOutboxImpl(
+      clock,
+      [:],
+      monitorLocksProvider,
+      Mock(OutboxLocksProvider),
+      store,
+      Mock(InstantOutboxPublisher),
+      Mock(OutboxItemFactory),
+      DURATION_ONE_HOUR,
+      executor,
+      decorators,
+      threadPoolTimeOut,
+      processingHostComposer,
+      instantProcessingEnabled
+    )
   }
 }

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxShutdownSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxShutdownSpec.groovy
@@ -48,7 +48,8 @@ class OutboxShutdownSpec extends Specification {
       executor,
       [],
       threadPoolTimeOut,
-      processingHostComposer
+      processingHostComposer,
+      false
     )
   }
 

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/TransactionalOutboxBuilderSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/TransactionalOutboxBuilderSpec.groovy
@@ -7,6 +7,7 @@ import io.github.bluegroundltd.outbox.TransactionalOutboxBuilder
 import io.github.bluegroundltd.outbox.TransactionalOutboxImpl
 import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher
 import io.github.bluegroundltd.outbox.item.OutboxType
+import io.github.bluegroundltd.outbox.processing.OutboxItemProcessorDecorator
 import io.github.bluegroundltd.outbox.store.OutboxStore
 import io.github.bluegroundltd.outbox.utils.DummyOutboxHandler
 import io.github.bluegroundltd.outbox.utils.UnitTestSpecification
@@ -33,7 +34,7 @@ class TransactionalOutboxBuilderSpec extends UnitTestSpecification {
       def mockedBType = GroovyMock(OutboxType)
       def handlers = Set.of(handlerA, handlerB)
       def expectedOutboxTypes = Set.of(handlerA.getSupportedType(), mockedBType)
-
+      def decorator = GroovyMock(OutboxItemProcessorDecorator)
 
     when:
       def transactionalOutboxBuilder = builder
@@ -42,6 +43,9 @@ class TransactionalOutboxBuilderSpec extends UnitTestSpecification {
         .withCleanupLocksProvider(cleanupLocksProvider)
         .withStore(store)
         .withInstantOutboxPublisher(instantOutboxPublisher)
+        .withInstantOrderingEnabled(generateBoolean())
+        .withThreadPriority(generateIntNonZero(10))
+        .addProcessorDecorator(decorator)
 
     and:
       TransactionalOutbox transactionalOutbox


### PR DESCRIPTION
## Description

### ✨ Features  

 - Adds `instantOrderingEnabled` flag
   > Flag which indicates whether new instant processing mechanism should be used or not.

   > The new mechanism uses `monitor` to fetch the item along with its group sibling items and support their ordering
   > while the old mechanism processes the instant outbox item directly without fetching it from store.

   > One downside of the new mechanism is that the advisory locks will be used more frequently which may result
some delays on the monitor executions.

   > Both mechanisms will be kept and switch via this flag until the old one eventually gets dropped.
### ♻️  Refactoring  
- Refactors `processInstantOutbox` to use `monitor` with hint
   > This is required in order to be able to execute all items that potentially belong to the same group as the one being instantly processed.

   > Since hint (outbox id) is passed through the filter, clients can manipulate how the item is retrieved via `fetch`. To ensure
that we execute only this item in case of an erroneous fetch implementation, we also filter it on runtime.

   > Also added `@Deprecated` since this method will eventually be dropped in favor of directly using monitor with a hint. 
### ⬆️ Version
- Bumps core lib version to `2.2.0`

Resolves [[SW-581]]

[SW-581]: https://devblueground.atlassian.net/browse/SW-581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ