### PR TITLE
[SW-699] Update outbox handling logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Transactional Outbox is published on `mavenCentral`. In order to use it just add
 
 ```gradle
 
-implementation("io.github.bluegroundltd:transactional-outbox-core:2.3.0")
+implementation("io.github.bluegroundltd:transactional-outbox-core:2.3.1")
 
 ```
 

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=io.github.bluegroundltd
 POM_ARTIFACT_ID=transactional-outbox-core
-VERSION_NAME=2.3.0
+VERSION_NAME=2.3.1
 
 POM_NAME=Transactional Outbox Core
 POM_DESCRIPTION=Easily implement the transactional outbox pattern in your JVM application

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxHandlerException.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxHandlerException.kt
@@ -1,0 +1,17 @@
+package io.github.bluegroundltd.outbox.processing
+
+import io.github.bluegroundltd.outbox.item.OutboxItem
+
+internal data class OutboxHandlerException @JvmOverloads constructor(
+  private val item: OutboxItem,
+  override val cause: Throwable,
+  override val message: String = formatDefaultMessage(item, cause),
+) : RuntimeException(message, cause) {
+  companion object {
+    private fun formatDefaultMessage(item: OutboxItem, cause: Throwable) =
+      "Handler for outbox: ${item.id} failed${formatCauseMessage(cause.message)}."
+
+    private fun formatCauseMessage(message: String?): String =
+      message?.let { " with message: '$it'" } ?: ""
+  }
+}

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxItemProcessor.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxItemProcessor.kt
@@ -44,7 +44,7 @@ internal class OutboxItemProcessor(
       } else {
         handleRetryableFailure(handler, exception)
       }
-      throw exception
+      throw OutboxHandlerException(item, exception)
     } finally {
       store.update(item)
     }

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxItemProcessor.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxItemProcessor.kt
@@ -99,7 +99,7 @@ internal class OutboxItemProcessor(
   }
 
   private fun handleTerminalFailure(handler: OutboxHandler, exception: Exception) {
-    logger.info(
+    logger.error(
       "$LOGGER_PREFIX Failure handling outbox item with id: ${item.id} and type: ${item.type}. " +
         "Item reached max-retries (${item.retries}), delegating failure to handler.",
       exception

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/processing/OutboxHandlerExceptionSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/processing/OutboxHandlerExceptionSpec.groovy
@@ -1,0 +1,50 @@
+package io.github.bluegroundltd.outbox.processing
+
+import io.github.bluegroundltd.outbox.item.OutboxItem
+import io.github.bluegroundltd.outbox.utils.OutboxItemBuilder
+import spock.lang.Specification
+
+class OutboxHandlerExceptionSpec extends Specification {
+  def "Should build an [OutboxHandlerException] with default values"() {
+    given:
+      def outboxItem = OutboxItemBuilder.make().build()
+      def cause = Mock(Throwable)
+      def expectedMessage = outboxItem.with {
+        "Handler for outbox: ${it.id} failed${expectedCauseMessage}."
+      }
+
+    when:
+      def exception = new OutboxHandlerException(outboxItem, cause)
+
+    then:
+      1 * cause.getMessage() >> causeMessage
+      0 * _
+
+    and:
+      exception.cause == cause
+      exception.message == expectedMessage
+      0 * _
+
+    where:
+      causeMessage        || expectedCauseMessage
+      "Exception Message" || " with message: 'Exception Message'"
+      null                || ""
+  }
+
+  def "Should build an [OutboxHandlerException] with the supplied values"() {
+    given:
+      def outboxItem = GroovyMock(OutboxItem)
+      def cause = Mock(Throwable)
+      def message = "Exception Message"
+
+    when:
+      def exception = new OutboxHandlerException(outboxItem, cause, message)
+
+    then:
+      0 * _
+
+    and:
+      exception.message == message
+      exception.cause == cause
+  }
+}


### PR DESCRIPTION
## Description
Updates logging as it pertains to outbox handler failures in order to facilitate easier monitoring/identification of potential issues. This revolves around two axes:
- Make serious errors more prominent (e.g. increase log level to `error` for terminal failures).
- Limit the number of non-essential logs (i.e. retry-able failures).

### Reference
Resolves [[SW-699]](https://devblueground.atlassian.net/browse/SW-699).

[SW-699]: https://devblueground.atlassian.net/browse/SW-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ