### PR TITLE
[SW-580] Make instant outbox items eligible for processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Transactional Outbox is published on `mavenCentral`. In order to use it just add
 
 ```gradle
 
-implementation("io.github.bluegroundltd:transactional-outbox-core:2.3.1")
+implementation("io.github.bluegroundltd:transactional-outbox-core:2.3.2")
 
 ```
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,20 @@
 
 ## v.2.x.x
 
+### v.2.3.2 - Fix for legacy instant processing and insertion hints
+
+Release 2.3.2 fixes the legacy instant processing (i.e. when `instantOrderingEnabled` is set to `false`) which was
+broken since 2.3. The fix
+introduces a flow where the outbox item is first inserted and then immediately updated for processing.
+
+#### Persistence changes
+
+The updated insertion implementation for instant processing introduces a flow where both `OutboxStore#insert` and
+`OutboxStore#update` are called. In turn, this means that the corresponding implementations may need to be updated to
+support it. Since this might have performance implications (e.g. requiring flushing the date to the underlying
+database), the library now provides a set of hints (`OutboxInsertionHint`) to allow for implementors to appropriately
+optimize. 
+
 ### v.2.3.0 - Support for grouping and ordering outbox items
 
 Release 2.3.0 introduces support for grouping and ordering outbox items. Applications that want to take advantage of

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -56,7 +56,7 @@ tasks.withType<JacocoCoverageVerification> {
     rule {
       limit {
         counter = "INSTRUCTION"
-        minimum = "0.95".toBigDecimal()
+        minimum = "0.94".toBigDecimal()
       }
     }
     rule {

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=io.github.bluegroundltd
 POM_ARTIFACT_ID=transactional-outbox-core
-VERSION_NAME=2.3.1
+VERSION_NAME=2.3.2
 
 POM_NAME=Transactional Outbox Core
 POM_DESCRIPTION=Easily implement the transactional outbox pattern in your JVM application

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutboxBuilder.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutboxBuilder.kt
@@ -3,9 +3,9 @@ package io.github.bluegroundltd.outbox
 import io.github.bluegroundltd.outbox.event.InstantOutboxPublisher
 import io.github.bluegroundltd.outbox.executor.FixedThreadPoolExecutorServiceFactory
 import io.github.bluegroundltd.outbox.grouping.DefaultGroupingConfiguration
-import io.github.bluegroundltd.outbox.grouping.OutboxGroupingConfiguration
-import io.github.bluegroundltd.outbox.grouping.OutboxGroupIdProvider
 import io.github.bluegroundltd.outbox.grouping.NullGroupIdProvider
+import io.github.bluegroundltd.outbox.grouping.OutboxGroupIdProvider
+import io.github.bluegroundltd.outbox.grouping.OutboxGroupingConfiguration
 import io.github.bluegroundltd.outbox.grouping.SingleItemGroupingConfiguration
 import io.github.bluegroundltd.outbox.item.OutboxType
 import io.github.bluegroundltd.outbox.item.factory.OutboxItemFactory
@@ -222,7 +222,7 @@ class TransactionalOutboxBuilder(
    */
   override fun build(): TransactionalOutbox {
     val executorServiceFactory = FixedThreadPoolExecutorServiceFactory(threadPoolSize, threadPriority)
-    val outboxItemFactory = OutboxItemFactory(clock, handlers.toMap(), rerunAfterDuration, groupIdProvider)
+    val outboxItemFactory = OutboxItemFactory(handlers.toMap(), groupIdProvider)
 
     return TransactionalOutboxImpl(
       clock,

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutboxImpl.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/TransactionalOutboxImpl.kt
@@ -59,12 +59,23 @@ internal class TransactionalOutboxImpl(
   override fun add(type: OutboxType, payload: OutboxPayload, shouldPublishAfterInsertion: Boolean) {
     logger.info("$LOGGER_PREFIX Adding item of type: ${type.getType()} and payload: $payload")
 
-    when {
-      shouldPublishAfterInsertion && !instantOrderingEnabled -> outboxItemFactory.makeInstantOutbox(type, payload)
-      else -> outboxItemFactory.makeScheduledOutboxItem(type, payload)
-    }.run { outboxStore.insert(this) }
-      .takeIf { shouldPublishAfterInsertion }
-      ?.let { instantOutboxPublisher.publish(InstantOutboxEvent(outbox = it)) }
+    // Build scheduled outbox item and insert it. Alternatively, for instant outboxes we could prepare for
+    // processing before inserting it. But then we would need to devise a method to allow us for updating
+    // `markedForProcessing` based on the originally built item.
+    val outboxItem = outboxItemFactory.makeScheduledOutboxItem(type, payload)
+      .run { outboxStore.insert(this) }
+
+    if (shouldPublishAfterInsertion) {
+      if (!instantOrderingEnabled) {
+        // When instant ordering is not enabled (i.e. legacy instant processing), the item will be used from the
+        // processing method (i.e. `processInstantOutbox`) directly (i.e. will not be retrieved from the database).
+        // Therefore, we need to prepare/update it for processing so that any other possible concurrent operations
+        // do not pick it up. (This is essentially what `monitor` also does.)
+        val now = Instant.now(clock)
+        outboxItem.updateForProcessing(now, now + rerunAfterDuration)
+      }
+      instantOutboxPublisher.publish(InstantOutboxEvent(outbox = outboxItem))
+    }
   }
 
   @Deprecated(
@@ -106,7 +117,7 @@ internal class TransactionalOutboxImpl(
         .map { it.copy() } // Defensive copy to avoid external modifications.
         .group()
         .filterByIdIfExists(id) // ensures item filtering regardless of client's `fetch`
-        .apply { prepareForProcessing() } // mark groups (essentially contained items) for processing
+        .apply { updateForProcessing() } // mark groups (essentially contained items) for processing
         .forEach { it.process() }
     }.onFailure {
       logger.error("$LOGGER_PREFIX Failure in monitor", it)
@@ -137,12 +148,19 @@ internal class TransactionalOutboxImpl(
     return eligibleItems
   }
 
-  private fun List<OutboxItemGroup>.prepareForProcessing() {
+  private fun List<OutboxItemGroup>.updateForProcessing() {
     val now = Instant.now(clock)
     val rerunAfter = now.plus(rerunAfterDuration)
-    flatMap { it.items }
-      .onEach { it.prepareForProcessing(now, rerunAfter) }
-      .onEach { outboxStore.update(it) }
+    flatMap { it.items }.onEach { it.updateForProcessing(now, rerunAfter) }
+  }
+
+  private fun OutboxItem.updateForProcessing(now: Instant, rerunAfter: Instant) {
+    // It is important to NOT return the item returned from `update` since it may be a different instance
+    // where the `markedForProcessing` flag is not properly set.
+    // Rerunning `prepareForProcessing` on it, wouldn't work since **by design** (i.e. when retrieving items
+    // that have been updated for processing from another thread / instance) the function will not work on them.
+    prepareForProcessing(now, rerunAfter)
+    outboxStore.update(this)
   }
 
   private fun List<OutboxItem>.group(): List<OutboxItemGroup> = groupingProvider.execute(this)

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/item/OutboxItem.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/item/OutboxItem.kt
@@ -38,7 +38,7 @@ data class OutboxItem(
    * eligible for processing and is marked as such.
    */
   fun prepareForProcessing(now: Instant, rerunAfter: Instant) {
-    markedForProcessing = isEligibleForProcessing(now)
+    markedForProcessing = markedForProcessing || isEligibleForProcessing(now)
     if (markedForProcessing) {
       status = OutboxStatus.RUNNING
       lastExecution = now

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/store/OutboxStore.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/store/OutboxStore.kt
@@ -15,6 +15,8 @@ interface OutboxStore {
    */
   fun insert(outboxItem: OutboxItem): OutboxItem
 
+  fun insert(outboxItem: OutboxItem, hints: OutboxStoreInsertHints): OutboxItem = insert(outboxItem)
+
   /**
    * Updates an outbox item in the store.
    *

--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/store/OutboxStoreInsertHints.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/store/OutboxStoreInsertHints.kt
@@ -1,0 +1,6 @@
+package io.github.bluegroundltd.outbox.store
+
+data class OutboxStoreInsertHints(
+  val forInstantProcessing: Boolean,
+  val instantOrderingEnabled: Boolean
+)

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/item/OutboxItemSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/item/OutboxItemSpec.groovy
@@ -62,39 +62,64 @@ class OutboxItemSpec extends Specification {
       def itemBuilder = OutboxItemBuilder.make()
         .withStatus(OutboxStatus.PENDING)
         .withNextRun(BEFORE_NOW)
-
       def outboxItem = itemBuilder.build()
 
     and:
+      def firstPrepareNow = NOW
+      def firstPrepareRerunAfter = NOW.plusSeconds(1000)
       def rerunAfter = NOW.plusSeconds(1000)
-      def expectedItem = itemBuilder
+      def expectedItemAfterFirstPrepare = itemBuilder
         .withStatus(OutboxStatus.RUNNING)
-        .withRerunAfter(rerunAfter)
-        .withLastExecution(NOW)
+        .withRerunAfter(firstPrepareRerunAfter)
+        .withLastExecution(firstPrepareNow)
         .build()
 
-    when:
-      outboxItem.prepareForProcessing(NOW, rerunAfter)
+    and:
+      def secondPrepareNow = firstPrepareNow.plusSeconds(100)
+      def secondPrepareRerunAfter = firstPrepareRerunAfter.plusSeconds(100)
+      def expectedItemAfterSecondPrepare = itemBuilder
+        .withStatus(OutboxStatus.RUNNING)
+        .withRerunAfter(secondPrepareRerunAfter)
+        .withLastExecution(secondPrepareNow)
+        .build()
 
-    then:
-      outboxItem == expectedItem
+    when: "prepareForProcessing is invoked"
+      outboxItem.prepareForProcessing(firstPrepareNow, firstPrepareRerunAfter)
+
+    then: "The item is updated and marked for processing"
+      outboxItem == expectedItemAfterFirstPrepare
+      outboxItem.markedForProcessing
+
+    when: "prepareForProcessing is invoked again"
+      outboxItem.prepareForProcessing(NOW.plusSeconds(100), rerunAfter.plusSeconds(100))
+
+    then: "The item is again updated and is still marked for processing"
+      outboxItem == expectedItemAfterSecondPrepare
+      outboxItem.markedForProcessing
   }
 
   def "Should not update any fields when 'prepareForProcessing' is called and the item is not eligible for processing"() {
     given:
       def itemBuilder = OutboxItemBuilder.make()
         .withStatus(OutboxStatus.COMPLETED)
-
       def outboxItem = itemBuilder.build()
 
     and:
       def rerunAfter = NOW.plusSeconds(1000)
       def expectedItem = itemBuilder.build()
 
-    when:
+    when: "prepareForProcessing is invoked"
       outboxItem.prepareForProcessing(NOW, rerunAfter)
 
-    then:
+    then: "The item remains unchanged and is not marked for processing"
       outboxItem == expectedItem
+      !outboxItem.markedForProcessing
+
+    when: "prepareForProcessing is invoked again"
+      outboxItem.prepareForProcessing(NOW.plusSeconds(100), rerunAfter.plusSeconds(100))
+
+    then: "The item again remains unchanged and is still not marked for processing"
+      outboxItem == expectedItem
+      !outboxItem.markedForProcessing
   }
 }

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxAddSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxAddSpec.groovy
@@ -67,19 +67,21 @@ class OutboxAddSpec extends UnitTestSpecification {
       def type = GroovyMock(OutboxType)
 
     and:
-      def outboxItem = OutboxItemBuilder.make().build()
-      def savedOutbox = OutboxItemBuilder.make().build()
+      def newOutbox = OutboxItemBuilder.makePending().build()
+      def insertedOutbox = OutboxItemBuilder.makePending().build()
+      def updatedOutbox = OutboxItemBuilder.make().build()
 
     when:
       transactionalOutbox.add(type, payload, true)
 
     then:
       1 * type.getType() >> "type"
-      (instantProcessingEnabled ? 1 : 0) * outboxItemFactory.makeScheduledOutboxItem(type, payload) >> outboxItem
-      (instantProcessingEnabled ? 0 : 1) * outboxItemFactory.makeInstantOutbox(type, payload) >> outboxItem
-      1 * store.insert(outboxItem) >> savedOutbox
+      1 * outboxItemFactory.makeScheduledOutboxItem(type, payload) >> newOutbox
+      1 * store.insert(newOutbox) >> insertedOutbox
+      (instantProcessingEnabled ? 0 : 1) * store.update(insertedOutbox) >> updatedOutbox
       1 * instantOutboxPublisher.publish({
-        assert it.outbox == savedOutbox
+        // Verify that it is actually the originally inserted outbox (and not the updated one) that it is published.
+        assert it.outbox == insertedOutbox
       })
       0 * _
 

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxMonitorSpec.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/unit/OutboxMonitorSpec.groovy
@@ -47,7 +47,10 @@ class OutboxMonitorSpec extends Specification {
 
   def "Should delegate to the executor thread pool when an instant outbox is processed and `instantProcessingEnabled` is false"() {
     given:
-      def instantOutbox = OutboxItemBuilder.makePending().build()
+      def instantOutbox = OutboxItemBuilder.makePending().build().with {
+        it.prepareForProcessing(Instant.now(clock), Instant.now(clock) + DURATION_ONE_HOUR)
+        it
+      }
       def processingHost = Mock(OutboxProcessingHost)
 
     when:

--- a/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/InMemoryOutboxStore.groovy
+++ b/core/src/test/groovy/io/github/bluegroundltd/outbox/utils/InMemoryOutboxStore.groovy
@@ -4,6 +4,7 @@ import io.github.bluegroundltd.outbox.item.OutboxItem
 import io.github.bluegroundltd.outbox.item.OutboxStatus
 import io.github.bluegroundltd.outbox.store.OutboxFilter
 import io.github.bluegroundltd.outbox.store.OutboxStore
+import io.github.bluegroundltd.outbox.store.OutboxStoreInsertHints
 import org.jetbrains.annotations.NotNull
 
 import java.time.Instant
@@ -15,6 +16,11 @@ class InMemoryOutboxStore implements OutboxStore {
   OutboxItem insert(@NotNull OutboxItem outboxItem) {
     outboxItems[outboxItem.id] = outboxItem
     return outboxItem
+  }
+
+  @Override
+  OutboxItem insert(@NotNull OutboxItem outboxItem, @NotNull OutboxStoreInsertHints hints) {
+    insert(outboxItem)
   }
 
   @Override


### PR DESCRIPTION
## Description
Since `OutboxItemProcessor` has been updated to check processing eligibility through `markedForProcessing`, it has been failing for legacy instant outboxes that don't move through the `monitor` flow.

Accordingly, we need to update the building of the instant outboxes to make sure that `prepareForProcessing` is also called for them. It turns out that the basic difference between `makeScheduledOutboxItem` and `makeInstantOutbox` is actually exactly that, i.e. the latter is also 'preparing' the item for processing (albeit without 'marking' them). Therefore, `TransactionalOutboxImpl#add` has been refactored to always call `makeScheduledOutboxItem` and then conditionally also call `updateForProcessing` on the returned item.

### Additional Changes
- `OutboxItem#prepareForProcessing` has been made reentrant which allow for it to be called multiple times without affecting its outcome. There is no actual use case for this but it seems more friendly to the developer.
- Support hints when inserting items: Transactional outbox is now supplying hints to `OutboxStore` when inserting items. The hints provide additional context for the current operation and the transactional outbox configuration.
In turn, the store can use the hints to provide a more appropriate / performant implementation for the insertion operation. The functionality is implemented as `OutboxStore#insert(item, hints)`, i.e. an overload of the existing `OutboxStore#insert(item)` method. It has a default implementation that simply calls the latter. Therefore, if the implementing code does not wish to take advantage of the feature, they can simply ignore it.

## Reference
Fixes a small bug introduced in https://github.com/bluegroundltd/transactional-outbox/pull/32.