### PR TITLE
fix: Error handling on processor

### DIFF
--- a/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxProcessingHost.kt
+++ b/core/src/main/kotlin/io/github/bluegroundltd/outbox/processing/OutboxProcessingHost.kt
@@ -31,10 +31,10 @@ internal class OutboxProcessingHost(
   }
 
   private val processorRunnable = Runnable {
-    try {
+    runCatching {
       processingAction.run()
-    } catch (e: Exception) {
-      e.log()
+    }.onFailure {
+      it.log()
       processingAction.reset()
     }
   }
@@ -49,7 +49,7 @@ internal class OutboxProcessingHost(
     processingAction.reset()
   }
 
-  private fun Exception.log() {
+  private fun Throwable.log() {
     when (this) {
       // Outbox handler exceptions are logged by the item processor itself.
       is OutboxHandlerException -> {}


### PR DESCRIPTION
The current implementation used a try-catch and only handled exceptions that extended `Exception`. In case a different exception was raised, nothing
is logged.

By replacing it with a `runCatching` we ensure that any throwable is handled.

