### PR TITLE
Remove `@Component` annotation from spring schedulers

### DIFF
--- a/spring/gradle.properties
+++ b/spring/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=io.github.bluegroundltd
 POM_ARTIFACT_ID=transactional-outbox-spring
-VERSION_NAME=0.0.1
+VERSION_NAME=0.0.2
 
 POM_NAME=Transactional Outbox For Spring
 POM_DESCRIPTION=Easily implement the transactional outbox pattern in your Spring application

--- a/spring/src/main/kotlin/io/github/bluegroundltd/springoutbox/SpringOutboxCleaner.kt
+++ b/spring/src/main/kotlin/io/github/bluegroundltd/springoutbox/SpringOutboxCleaner.kt
@@ -2,11 +2,9 @@ package io.github.bluegroundltd.springoutbox
 
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
-import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
-@Component
-internal class SpringOutboxCleaner(
+open class SpringOutboxCleaner(
   private val transactionalOutbox: TransactionalOutbox,
 ) : OutboxCleaner {
   companion object {

--- a/spring/src/main/kotlin/io/github/bluegroundltd/springoutbox/SpringOutboxScheduler.kt
+++ b/spring/src/main/kotlin/io/github/bluegroundltd/springoutbox/SpringOutboxScheduler.kt
@@ -2,11 +2,9 @@ package io.github.bluegroundltd.springoutbox
 
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
-import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
-@Component
-internal class SpringOutboxScheduler(
+open class SpringOutboxScheduler(
   private val transactionalOutbox: TransactionalOutbox,
 ) : OutboxScheduler {
   companion object {

--- a/spring/src/main/kotlin/io/github/bluegroundltd/springoutbox/SpringOutboxShutdown.kt
+++ b/spring/src/main/kotlin/io/github/bluegroundltd/springoutbox/SpringOutboxShutdown.kt
@@ -1,10 +1,8 @@
 package io.github.bluegroundltd.springoutbox
 
 import jakarta.annotation.PreDestroy
-import org.springframework.stereotype.Component
 
-@Component
-internal class SpringOutboxShutdown(
+open class SpringOutboxShutdown(
   private val transactionalOutbox: TransactionalOutbox,
 ) : OutboxShutdown {
 


### PR DESCRIPTION
The scheduler beans should only be configured through the Autoconfiguration class.

[NO-JIRA]